### PR TITLE
test: intentionally broken bash for CI failure wake [DO NOT MERGE]

### DIFF
--- a/hooks/intentional-broken-script-for-ci-test.sh
+++ b/hooks/intentional-broken-script-for-ci-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# THIS SCRIPT IS INTENTIONALLY BROKEN.
+# It exists ONLY to verify that CI failure wake events are delivered
+# to the originating Claude Code session via the FIFO push-wake mechanism.
+# The PR containing this file MUST NOT be merged — close it after the
+# failure wake event has been received.
+#
+# Below is a deliberate bash syntax error that bash -n will catch:
+
+if then
+    echo "this never runs"
+fi


### PR DESCRIPTION
<!-- claude-session: b68de255-e271-4c80-b1d6-0d4a9d121a82 -->

## Summary
**DO NOT MERGE.** This PR contains a bash script with an intentional `if then` syntax error.

End-to-end negative test of the FIFO push-wake mechanism — verifies that a CI failure event is delivered to the originating Claude Code session.

## Test plan
- [ ] CI bash -n step fails (expected)
- [ ] Failure wake event arrives at THIS session
- [ ] PR is closed without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)