### PR TITLE
fix(#27,#28): aggregate CI status + dedup duplicate events

### DIFF
--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -401,13 +401,14 @@ process_event_file() {
 #   Olbrasoft-cr-verify-abc1234-241234-1.json
 #   Olbrasoft-cr-verify-abc1234-241235-1.json   # re-run
 #
-# Both files contain the same (event_type, commit) tuple. We pick the file
-# with the LATEST timestamp inside the JSON for each (event_type, commit)
-# key, deliver only that one, and drop the rest. This ensures the consumer
-# session is woken at most once per logical event per wake-claude.sh call.
+# Both files contain the same (event_type, commit, environment) tuple. We
+# pick the file with the LATEST timestamp inside the JSON for each tuple,
+# deliver only that one, and drop the rest. The dedup key includes the
+# environment so events for staging vs production on the same commit are
+# NOT treated as duplicates.
 
-declare -A event_winner   # key: "event_type|commit" → file path
-declare -A event_winner_ts  # key: "event_type|commit" → timestamp
+declare -A event_winner   # key: "event_type|commit|env" → file path
+declare -A event_winner_ts  # key: "event_type|commit|env" → timestamp
 
 for ef in "$EVENTS_DIR"/${REPO_FILE}*.json; do
     [ -f "$ef" ] || continue
@@ -418,12 +419,13 @@ for ef in "$EVENTS_DIR"/${REPO_FILE}*.json; do
     fi
     et=$(jq -r '.event // ""' "$ef" 2>/dev/null)
     sha=$(jq -r '.commit // ""' "$ef" 2>/dev/null)
+    env=$(jq -r '.environment // ""' "$ef" 2>/dev/null)
     ts=$(jq -r '.timestamp // ""' "$ef" 2>/dev/null)
     # If we cannot identify the logical key, treat the file as unique.
     if [ -z "$et" ] || [ -z "$sha" ]; then
         continue
     fi
-    key="$et|$sha"
+    key="$et|$sha|$env"
     if [ -z "${event_winner[$key]:-}" ] || [[ "$ts" > "${event_winner_ts[$key]:-}" ]]; then
         # Drop the previous winner for this key (it is a logical duplicate
         # superseded by a newer file).

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -145,7 +145,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         repo = payload.get("repository", {})
         repo_name = repo.get("full_name", "unknown")
         repo_file = repo_name.replace("/", "-")
-        head_sha = check_suite.get("head_sha", "unknown")[:7]
+        head_sha = check_suite.get("head_sha", "unknown")
+        head_sha_short = head_sha[:7] if head_sha != "unknown" else head_sha
         head_branch = check_suite.get("head_branch", "")
 
         # Only for PRs — check if there are associated pull requests
@@ -162,7 +163,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # to wait for, OR there may still be checks in progress.
         agg = self._aggregate_pr_checks(repo_name, pr_number)
         if agg is None:
-            print(f"[webhook-receiver] PR #{pr_number}: gh pr checks failed, skipping wake",
+            print(f"[webhook-receiver] PR #{pr_number}: gh pr view --json statusCheckRollup "
+                  f"failed, skipping wake",
                   file=sys.stderr)
             return
 
@@ -177,7 +179,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
         # Idempotency: if we have already emitted an event for this exact
         # (PR, head SHA, status) tuple in a recent file, skip. We use the
-        # event filename as the idempotency key — it includes the head SHA.
+        # event filename as the idempotency key — it includes the FULL head
+        # SHA (40 chars). Truncated 7-char SHAs are not guaranteed unique
+        # and could let one commit's event clobber another commit's event
+        # for the same PR.
         event_file = os.path.join(EVENTS_DIR, f"{repo_file}-ci-{pr_number}-{head_sha}.json")
         if os.path.exists(event_file):
             try:
@@ -185,7 +190,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     existing = json.load(f)
                 if existing.get("status") == final_status:
                     print(f"[webhook-receiver] PR #{pr_number}: ci-complete with "
-                          f"status={final_status} for {head_sha} already emitted, skipping",
+                          f"status={final_status} for {head_sha_short} already emitted, skipping",
                           file=sys.stderr)
                     return
             except (json.JSONDecodeError, OSError):
@@ -196,7 +201,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             "status": final_status,
             "repository": repo_name,
             "prNumber": pr_number,
-            "commit": head_sha,
+            "commit": head_sha_short,
             "branch": pr_branch,
             "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
@@ -210,14 +215,14 @@ class WebhookHandler(BaseHTTPRequestHandler):
         os.rename(tmp_file, event_file)
 
         print(f"[webhook-receiver] CI {final_status} event written: {repo_name} PR #{pr_number} "
-              f"(branch: {pr_branch}, commit: {head_sha}, "
+              f"(branch: {pr_branch}, commit: {head_sha_short}, "
               f"checks: {agg['success']}s/{agg['failure']}f/{agg['skipped']}skip)",
               file=sys.stderr)
 
         _wake(repo_name, pr_branch)
 
     def _aggregate_pr_checks(self, repo_name, pr_number):
-        """Query `gh pr checks` for the aggregate status of all checks on a PR.
+        """Query `gh pr view --json statusCheckRollup` for the aggregate status of all checks on a PR.
 
         Returns a dict with keys:
           all_terminal (bool): True if every check is in a terminal state
@@ -255,9 +260,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 continue
             if conclusion == "SUCCESS":
                 success += 1
-            elif conclusion == "FAILURE":
+            elif conclusion in ("FAILURE", "CANCELLED"):
+                # CANCELLED checks are non-success and should block merging.
+                # If a check was cancelled (manually or by infra), the
+                # consumer must NOT treat the PR as cleanly green.
                 failure += 1
-            elif conclusion in ("SKIPPED", "NEUTRAL", "CANCELLED"):
+            elif conclusion in ("SKIPPED", "NEUTRAL"):
                 skipped += 1
             elif not conclusion:
                 # Empty conclusion typically means still pending in some


### PR DESCRIPTION
<!-- claude-session: b68de255-e271-4c80-b1d6-0d4a9d121a82 -->

## Summary
Fixes two correctness bugs in the wake mechanism, both surfaced during the end-to-end testing in PR #25.

Closes #27
Closes #28

## #27 — Premature CI success events

`webhook-receiver.py` was overwriting the per-PR `ci-complete` event file on every `check_suite` webhook. With multiple check suites per PR (GitHub Actions, GitGuardian, …), the file could be written first as `success` and later as `failure` (or vice versa), so the consumer session received a misleading premature event.

**New behavior:** every `check_suite` event triggers a re-evaluation of the PR's full aggregated check status via `gh pr view --json statusCheckRollup`. We only emit the `ci-complete` event when all checks are in a terminal state, and the status is the worst conclusion (any failure → failure, otherwise success). The event filename now includes the head SHA (`{repo}-ci-{pr}-{sha}.json`) for per-commit idempotency.

Both `_handle_review` and `_handle_check_suite` now write events atomically (tempfile + rename), eliminating the `[wake-on-event] event payload is not valid JSON` diagnostics caused by readers seeing partially-written files.

## #28 — Duplicate verify/deploy events from re-runs

Deploy and verify event files from GitHub Actions runners include `{run_id}-{run_attempt}` in the filename. Workflow re-runs (manual via UI, automatic retry) write additional files for the same logical event, causing duplicate wake notifications.

**New behavior:** before delivering anything, `wake-claude.sh` groups all matching event files by `(event_type, commit)` and keeps only the file with the newest `timestamp` JSON field. Older duplicates are deleted. This works regardless of the filename scheme used by consumer workflows.

## Test plan
- [x] Python syntax check on webhook-receiver.py
- [x] Bash syntax check on wake-claude.sh
- [x] Manual dedup test: 3 verify events for the same commit → 2 dropped as superseded → 1 delivered (latest timestamp)
- [ ] CI passes
- [ ] Copilot review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)