### PR TITLE
fix: in-memory dedup for ci-complete events (no more duplicates)

### DIFF
--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -8,12 +8,59 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9877
 EVENTS_DIR = os.path.expanduser("~/.config/claude-channels/deploy-events")
 os.makedirs(EVENTS_DIR, exist_ok=True)
+
+
+# In-memory dedup cache for emitted CI events. Key:
+#   (repo_name, pr_number, head_sha, status)
+# Value: epoch seconds when this tuple was last emitted.
+#
+# Why we need this on top of the file-existence check:
+#   1. webhook-receiver writes the event JSON file to deploy-events
+#   2. webhook-receiver calls wake-claude.sh
+#   3. wake-claude.sh reads the file, delivers via FIFO, **deletes** it
+#   4. Another check_suite event arrives for the SAME (PR, commit, status)
+#      a few seconds later (e.g. one workflow finishes after another for
+#      the same head SHA — happens frequently with multi-job workflows)
+#   5. webhook-receiver checks os.path.exists(event_file) → False
+#      (because wake-claude.sh deleted it in step 3)
+#   6. webhook-receiver writes a NEW file → new wake event for the
+#      same logical CI completion
+#
+# The in-memory cache survives wake-claude.sh's file deletion, so step 5
+# becomes "in-memory cache hit → skip" instead of "file missing → re-emit".
+# Entries expire after CI_DEDUP_TTL_SECONDS so a genuinely-new commit on
+# the same PR can still emit cleanly later.
+_ci_dedup_cache = {}
+_ci_dedup_lock = threading.Lock()
+CI_DEDUP_TTL_SECONDS = 600  # 10 minutes
+
+
+def _ci_dedup_check_and_mark(repo_name, pr_number, head_sha, status):
+    """Return True if this (repo, pr, commit, status) was already emitted
+    recently. Otherwise mark it as emitted and return False.
+
+    Thread-safe under the receiver's HTTP server which uses a thread per
+    request via BaseHTTPServer's default ThreadingMixIn behaviour.
+    """
+    key = (repo_name, pr_number, head_sha, status)
+    now = time.time()
+    with _ci_dedup_lock:
+        # Garbage-collect expired entries opportunistically on every call
+        expired = [k for k, ts in _ci_dedup_cache.items()
+                   if now - ts > CI_DEDUP_TTL_SECONDS]
+        for k in expired:
+            del _ci_dedup_cache[k]
+        if key in _ci_dedup_cache:
+            return True
+        _ci_dedup_cache[key] = now
+        return False
 
 
 def _reap_in_background(proc):
@@ -215,12 +262,29 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # All checks are terminal. Determine the final status.
         final_status = "failure" if agg["any_failure"] else "success"
 
+        # In-memory dedup cache check. This survives wake-claude.sh's
+        # post-delivery deletion of the event file, so a second
+        # check_suite event arriving for the same (PR, commit, status)
+        # tuple a few seconds later — common when multiple GitHub
+        # workflows fire for the same head SHA — gets deduped here
+        # instead of generating a duplicate wake event. See top-of-file
+        # _ci_dedup_cache definition for full rationale.
+        if _ci_dedup_check_and_mark(repo_name, pr_number, head_sha, final_status):
+            print(f"[webhook-receiver] PR #{pr_number}: ci-complete with "
+                  f"status={final_status} for {head_sha_short} already emitted "
+                  f"(in-memory dedup), skipping",
+                  file=sys.stderr)
+            return
+
         # Idempotency: if we have already emitted an event for this exact
         # (PR, head SHA, status) tuple in a recent file, skip. We use the
         # event filename as the idempotency key — it includes the FULL head
         # SHA (40 chars). Truncated 7-char SHAs are not guaranteed unique
         # and could let one commit's event clobber another commit's event
-        # for the same PR.
+        # for the same PR. This branch only fires when the receiver was
+        # restarted between the first and second check_suite events
+        # (in-memory cache cleared) but the file is still present
+        # (wake-claude.sh has not yet processed it).
         event_file = os.path.join(EVENTS_DIR, f"{repo_file}-ci-{pr_number}-{head_sha}.json")
         if os.path.exists(event_file):
             try:
@@ -228,7 +292,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     existing = json.load(f)
                 if existing.get("status") == final_status:
                     print(f"[webhook-receiver] PR #{pr_number}: ci-complete with "
-                          f"status={final_status} for {head_sha_short} already emitted, skipping",
+                          f"status={final_status} for {head_sha_short} already emitted "
+                          f"(file still present), skipping",
                           file=sys.stderr)
                     return
             except (json.JSONDecodeError, OSError):

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -35,32 +35,60 @@ os.makedirs(EVENTS_DIR, exist_ok=True)
 #
 # The in-memory cache survives wake-claude.sh's file deletion, so step 5
 # becomes "in-memory cache hit → skip" instead of "file missing → re-emit".
-# Entries expire after CI_DEDUP_TTL_SECONDS so a genuinely-new commit on
-# the same PR can still emit cleanly later.
+#
+# Entries expire after CI_DEDUP_TTL_SECONDS to bound memory use and to
+# allow re-emission of the same (repo, PR, commit, status) tuple after
+# a while if some downstream consumer never picked it up. New commits
+# on the same PR are NOT blocked by the cache regardless of TTL,
+# because the head SHA is part of the key.
 _ci_dedup_cache = {}
 _ci_dedup_lock = threading.Lock()
 CI_DEDUP_TTL_SECONDS = 600  # 10 minutes
 
 
-def _ci_dedup_check_and_mark(repo_name, pr_number, head_sha, status):
-    """Return True if this (repo, pr, commit, status) was already emitted
-    recently. Otherwise mark it as emitted and return False.
+def _ci_dedup_expire_locked(now):
+    """Garbage-collect expired dedup entries.
 
-    Thread-safe under the receiver's HTTP server which uses a thread per
-    request via BaseHTTPServer's default ThreadingMixIn behaviour.
+    Caller must hold _ci_dedup_lock.
+    """
+    expired = [k for k, ts in _ci_dedup_cache.items()
+               if now - ts > CI_DEDUP_TTL_SECONDS]
+    for k in expired:
+        del _ci_dedup_cache[k]
+
+
+def _ci_dedup_check(repo_name, pr_number, head_sha, status):
+    """Return True if this (repo, pr, commit, status) was already emitted
+    recently, otherwise return False.
+
+    This helper does NOT mutate the dedup cache. The caller must invoke
+    _ci_dedup_mark_emitted() only AFTER the event has been successfully
+    persisted to disk, so that an exception during file I/O doesn't
+    cause the cache to silently suppress a legitimate retry for up to
+    CI_DEDUP_TTL_SECONDS.
+
+    Access to the cache is protected by a lock so this remains safe if
+    the receiver is ever run in a multi-threaded context.
     """
     key = (repo_name, pr_number, head_sha, status)
     now = time.time()
     with _ci_dedup_lock:
-        # Garbage-collect expired entries opportunistically on every call
-        expired = [k for k, ts in _ci_dedup_cache.items()
-                   if now - ts > CI_DEDUP_TTL_SECONDS]
-        for k in expired:
-            del _ci_dedup_cache[k]
-        if key in _ci_dedup_cache:
-            return True
+        _ci_dedup_expire_locked(now)
+        return key in _ci_dedup_cache
+
+
+def _ci_dedup_mark_emitted(repo_name, pr_number, head_sha, status):
+    """Record a successfully persisted CI event as emitted.
+
+    Call this only AFTER the event file has been written and renamed
+    into place — never before, otherwise a failure during file I/O
+    would suppress legitimate retries.
+    """
+    key = (repo_name, pr_number, head_sha, status)
+    now = time.time()
+    with _ci_dedup_lock:
+        _ci_dedup_expire_locked(now)
         _ci_dedup_cache[key] = now
-        return False
 
 
 def _reap_in_background(proc):
@@ -269,7 +297,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # workflows fire for the same head SHA — gets deduped here
         # instead of generating a duplicate wake event. See top-of-file
         # _ci_dedup_cache definition for full rationale.
-        if _ci_dedup_check_and_mark(repo_name, pr_number, head_sha, final_status):
+        #
+        # IMPORTANT: this is a non-mutating CHECK only. The cache is
+        # updated AFTER the event file has been successfully renamed
+        # into place (via _ci_dedup_mark_emitted). If the file write
+        # raises, the cache stays clean and a retry can still emit.
+        if _ci_dedup_check(repo_name, pr_number, head_sha, final_status):
             print(f"[webhook-receiver] PR #{pr_number}: ci-complete with "
                   f"status={final_status} for {head_sha_short} already emitted "
                   f"(in-memory dedup), skipping",
@@ -316,6 +349,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
         with open(tmp_file, "w") as f:
             json.dump(event, f, indent=2)
         os.rename(tmp_file, event_file)
+
+        # File is now safely on disk. Only NOW mark the dedup cache so
+        # that any exception above (open, json.dump, rename) leaves the
+        # cache untouched and a retry can still emit. See review on PR #45.
+        _ci_dedup_mark_emitted(repo_name, pr_number, head_sha, final_status)
 
         print(f"[webhook-receiver] CI {final_status} event written: {repo_name} PR #{pr_number} "
               f"(branch: {pr_branch}, commit: {head_sha_short}, "


### PR DESCRIPTION
<!-- claude-session: b68de255-e271-4c80-b1d6-0d4a9d121a82 -->

## Summary
User reported live duplicates: \"chyba, že ti přišel duplicitně. Každá událost ti musí přijít jenom jednou.\" Webhook-receiver logged two CI events for the same commit 36 seconds apart:

```
21:09:33 [webhook-receiver] CI success event written: PR #44 ... commit: 8a99d62 (1s/0f/0skip)
21:10:09 [webhook-receiver] CI success event written: PR #44 ... commit: 8a99d62 (5s/0f/0skip)
```

Same pattern at 21:13:35/21:14:17 for commit `b07da63`.

## Root cause
The existing file-based dedup check was broken because `wake-claude.sh` DELETES the event file after delivery:

1. webhook-receiver writes `<repo>-ci-<pr>-<sha>.json`
2. webhook-receiver calls wake-claude.sh
3. wake-claude.sh delivers via FIFO, **rm -f** the file
4. Second check_suite event arrives 36s later (another workflow finished)
5. webhook-receiver: `os.path.exists(event_file)` → False
6. webhook-receiver writes a NEW file → duplicate wake event

## Fix
In-memory dedup cache that **survives** the file deletion:

```python
_ci_dedup_cache = {}            # (repo, pr, commit, status) → epoch
_ci_dedup_lock = threading.Lock()
CI_DEDUP_TTL_SECONDS = 600

def _ci_dedup_check_and_mark(repo_name, pr_number, head_sha, status):
    ...
```

- Thread-safe under `threading.Lock` for the receiver's concurrent HTTP requests
- 10-minute TTL so a genuinely-new commit on the same PR can still emit later
- Garbage-collected opportunistically on every call
- Existing file-based check kept as second-line defence (receiver restart case)

## Test plan
- [x] `python3 -m py_compile` clean
- [ ] After install + restart of `gh-webhook-forward.service`: a PR push that fires multiple workflows produces exactly ONE ci-complete wake event per (PR, commit, status) tuple, not one per workflow