### PR TITLE
fix: actionable fallback + producer guard for invalid wake JSON

### DIFF
--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -305,6 +305,30 @@ write_with_retry() {
     local target_pid="$3"
     local deadline=$(($(date +%s) + WRITE_RETRY_SECS))
 
+    # Final guard: refuse to write garbage to the FIFO. The consumer's
+    # `read -r` followed by `jq empty` would otherwise fail and surface
+    # "[wake-on-event] event payload is not valid JSON" to the model.
+    # We re-validate at write time as a belt-and-suspenders check on top
+    # of the producer-side `jq -c .` in process_event_file. This catches
+    # any future code path that constructs $data without going through
+    # process_event_file's jq -c gate.
+    if ! printf '%s' "$data" | jq empty 2>/dev/null; then
+        log "REFUSE to write non-JSON payload to $fifo (length=${#data})"
+        return 1
+    fi
+    # Reject any payload that contains an embedded newline. The consumer
+    # reads ONE NDJSON line per `read -r`, so an embedded newline would
+    # split a single logical event across two reads — the first read
+    # gets a fragment that fails jq parse, and the second read consumes
+    # an unrelated event slot. jq -c would normally have stripped these
+    # already, but we re-check defensively.
+    case "$data" in
+        *$'\n'*)
+            log "REFUSE to write multi-line payload to $fifo (length=${#data})"
+            return 1
+            ;;
+    esac
+
     while [ "$(date +%s)" -lt "$deadline" ]; do
         # Re-check target liveness each iteration.
         if ! is_live_claude "$target_pid"; then

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -111,6 +111,34 @@ jq -n \
 # Event processing
 ###############################################################################
 
+# Forensics directory for invalid payloads. Each parse failure dumps the
+# raw bytes of the offending payload here so we can finally see what is
+# arriving on the FIFO when the consumer reports "not valid JSON". The
+# directory is created lazily so the script does not fail if HOME is unset.
+INVALID_PAYLOADS_DIR="$HOME/.config/claude-channels/invalid-payloads"
+
+# Dump a payload to the forensics directory for later inspection.
+# Returns the path of the dumped file on stdout (or empty on failure).
+dump_invalid_payload() {
+    local payload="$1"
+    local origin="$2"
+    mkdir -p "$INVALID_PAYLOADS_DIR" 2>/dev/null || return 0
+    local stamp
+    stamp=$(date -u +%Y%m%dT%H%M%SZ)
+    local out="$INVALID_PAYLOADS_DIR/${stamp}-pid${CLAUDE_PID}-${origin}.txt"
+    {
+        printf 'timestamp_utc: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        printf 'claude_pid: %s\n' "$CLAUDE_PID"
+        printf 'fifo: %s\n' "$FIFO"
+        printf 'origin: %s\n' "$origin"
+        printf 'payload_length_bytes: %s\n' "${#payload}"
+        printf '----- raw payload (od -c) -----\n'
+        printf '%s' "$payload" | od -c 2>/dev/null || true
+        printf '----- end raw payload -----\n'
+    } >"$out" 2>/dev/null
+    echo "$out"
+}
+
 # Render an event JSON payload as human-readable instructions on stderr.
 # Claude Code captures stderr and re-injects it as a system reminder when
 # we exit with code 2.
@@ -119,7 +147,28 @@ process_event() {
     [ -z "$event_data" ] && return 1
 
     if ! echo "$event_data" | jq empty 2>/dev/null; then
-        echo "[wake-on-event] event payload is not valid JSON" >&2
+        # Dump the offending payload so we can finally diagnose what
+        # producer is writing it. The dump goes to a separate forensics
+        # file (NOT stderr) so the system reminder stays compact and
+        # actionable.
+        local dump_path
+        dump_path=$(dump_invalid_payload "$event_data" "process_event")
+        {
+            echo "[wake-on-event] WAKE EVENT RECEIVED but payload was not valid JSON"
+            if [ -n "$dump_path" ]; then
+                echo "Raw bytes dumped to: $dump_path"
+            fi
+            echo ""
+            echo "DO NOT passively wait for another wake event. Instead:"
+            echo "  1. Identify which PR you are currently working on (the branch you pushed last)"
+            echo "  2. Check its state: gh pr view <PR> --repo <REPO> --json state,mergeable,mergeStateStatus,statusCheckRollup"
+            echo "  3. If state=OPEN and all CI checks are SUCCESS and Copilot has already reviewed (commented or approved) once, MERGE NOW:"
+            echo "       gh pr merge <PR> --repo <REPO> --merge --delete-branch"
+            echo "     Copilot reviews each PR EXACTLY ONCE — there will be NO second review wake event after a fix push."
+            echo "  4. If CI is still pending → continue your other work; another wake event will fire when it finishes."
+            echo "  5. If state=MERGED or CLOSED → there is nothing to do."
+            echo "  6. Notify user via mcp__notify__notify with what you decided."
+        } >&2
         return 1
     fi
 

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -113,20 +113,31 @@ jq -n \
 
 # Forensics directory for invalid payloads. Each parse failure dumps the
 # raw bytes of the offending payload here so we can finally see what is
-# arriving on the FIFO when the consumer reports "not valid JSON". The
-# directory is created lazily so the script does not fail if HOME is unset.
-INVALID_PAYLOADS_DIR="$HOME/.config/claude-channels/invalid-payloads"
+# arriving on the FIFO when the consumer reports "not valid JSON". Resolved
+# with explicit safe defaults for both XDG_CONFIG_HOME and HOME, since the
+# whole script runs under `set -u` and we must not abort if either env var
+# happens to be unset.
+INVALID_PAYLOADS_DIR=""
+if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    INVALID_PAYLOADS_DIR="$XDG_CONFIG_HOME/claude-channels/invalid-payloads"
+elif [ -n "${HOME:-}" ]; then
+    INVALID_PAYLOADS_DIR="$HOME/.config/claude-channels/invalid-payloads"
+fi
 
 # Dump a payload to the forensics directory for later inspection.
-# Returns the path of the dumped file on stdout (or empty on failure).
+# Returns the path of the dumped file on stdout if (and only if) the file
+# was actually created. On any failure (no dir, mkdir fails, write fails)
+# this prints nothing so callers don't claim a dump location that does
+# not exist on disk.
 dump_invalid_payload() {
     local payload="$1"
     local origin="$2"
+    [ -n "$INVALID_PAYLOADS_DIR" ] || return 0
     mkdir -p "$INVALID_PAYLOADS_DIR" 2>/dev/null || return 0
     local stamp
     stamp=$(date -u +%Y%m%dT%H%M%SZ)
     local out="$INVALID_PAYLOADS_DIR/${stamp}-pid${CLAUDE_PID}-${origin}.txt"
-    {
+    if {
         printf 'timestamp_utc: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         printf 'claude_pid: %s\n' "$CLAUDE_PID"
         printf 'fifo: %s\n' "$FIFO"
@@ -135,8 +146,9 @@ dump_invalid_payload() {
         printf '----- raw payload (od -c) -----\n'
         printf '%s' "$payload" | od -c 2>/dev/null || true
         printf '----- end raw payload -----\n'
-    } >"$out" 2>/dev/null
-    echo "$out"
+    } >"$out" 2>/dev/null && [ -s "$out" ]; then
+        echo "$out"
+    fi
 }
 
 # Render an event JSON payload as human-readable instructions on stderr.

--- a/skills/ci-workflow-monitor/SKILL.md
+++ b/skills/ci-workflow-monitor/SKILL.md
@@ -211,17 +211,36 @@ When `deploy-complete` has `status: failure`, the `failedStep` field tells you w
 
 ## State Machine
 
+The state machine is split into TWO phases by Copilot's review:
+
+**Phase A — initial commit, awaiting first Copilot review:**
+
 | State | Trigger | Autonomous Action |
 |---|---|---|
 | ISSUE_ASSIGNED | start | Implement, create branch, commit, push, create PR |
 | CI_PENDING | — | Silent wait (CI runs on GitHub cloud) |
-| CI_FAILED | — | Analyze logs → fix → push |
-| CI_PASSED | — | Wait for review push notification |
-| REVIEW_COMPLETE | push (asyncRewake) | Read comments, fix if any → push fixes → MERGE (no re-review will fire — Copilot reviews each PR exactly once, see Critical Rule #7) |
+| CI_FAILED | — | Analyze logs → fix → push (still in Phase A — back to CI_PENDING) |
+| CI_PASSED_AWAITING_REVIEW | — | Wait for `code-review-complete` push notification |
+| REVIEW_COMPLETE | push (asyncRewake) | Read comments, fix if any → push fixes → **transition to Phase B** |
+
+**Phase B — fix push after first Copilot review, NO second review will fire:**
+
+| State | Trigger | Autonomous Action |
+|---|---|---|
+| AWAITING_FIX_CI | — | Wait for `ci-complete` push notification on the fix commit |
+| FIX_CI_FAILED | push (asyncRewake) | Read failed logs, fix more, push (still Phase B — back to AWAITING_FIX_CI) |
+| FIX_CI_PASSED | push (asyncRewake) | **MERGE IMMEDIATELY** — Copilot reviews each PR EXACTLY ONCE, Critical Rule #7 applies. Do NOT mention "waiting for Copilot review" in notifications. Do NOT enter CI_PASSED_AWAITING_REVIEW again. |
 | PR_MERGED | — | Wait for deploy push notification |
+
+**Phase C — post-merge:**
+
+| State | Trigger | Autonomous Action |
+|---|---|---|
 | DEPLOY_COMPLETE | push (asyncRewake) | Verify production (health + Playwright) |
 | DEPLOY_FAILED | push (asyncRewake) | Notify error |
 | VERIFIED | after Playwright | Notify per-issue results → close issue |
+
+**Key invariant:** Phase B is NEVER re-entered if Copilot has already reviewed once. Once you have pushed a fix in response to Copilot, the next `ci-complete success` event always means MERGE. Notifications during Phase B must NOT include the phrase "čekám na Copilot review" / "waiting for Copilot review" — the only thing being waited on in Phase B is CI on the fix commit.
 
 ## Server / Docker Rules
 


### PR DESCRIPTION
<!-- claude-session: b68de255-e271-4c80-b1d6-0d4a9d121a82 -->

## Why

A Claude session working on cr#362 received a wake event whose payload failed `jq empty` validation. The consumer (`wake-on-event.sh`) emitted only the bare error \"[wake-on-event] event payload is not valid JSON\" to stderr and then exit 2 — Claude Code surfaced that as a system reminder with **no further guidance**, so the session passively waited for \"the next wake event\" that never came. The PR sat ready to merge for ~10 minutes before manual intervention.

This PR makes invalid wake events recoverable end-to-end:

## What

### 1. `wake-on-event.sh` — actionable fallback on parse failure

When `process_event()` rejects a payload:
- The raw bytes are dumped to `~/.config/claude-channels/invalid-payloads/` (timestamped, includes PID and FIFO path) so we can finally diagnose what producer is writing it.
- Stderr now emits a numbered, actionable instruction list: identify the current PR, run `gh pr view ... --json state,mergeable,mergeStateStatus,statusCheckRollup`, merge if state=OPEN + CI green + Copilot already reviewed, otherwise continue working. **Do NOT passively wait.**
- Reminds Claude that Copilot reviews each PR exactly ONCE and there will be no second review wake event after a fix push (Critical Rule #7).

### 2. `wake-claude.sh` — producer-side belt-and-suspenders guard

`write_with_retry()` now refuses to send to the FIFO if the payload either:
- Fails `printf '%s' \"$data\" | jq empty` validation, OR
- Contains an embedded newline (would split a single logical event across two consumer reads).

Both checks log a `REFUSE` line and return failure instead of writing garbage. This is on top of the existing `jq -c .` compaction in `process_event_file`, so any future code path that constructs `$data` without going through that gate is rejected before it can corrupt the FIFO.

## Test plan

- [x] Bash syntax check on both modified hooks
- [x] Unit-test the new `dump_invalid_payload` function — invalid input gets dumped
- [x] Unit-test producer guards: valid single-line JSON passes, multi-line is caught
- [x] `./hooks/install.sh --force` deploys to ~/.claude/hooks/ cleanly
- [x] webhook-receiver.service restarted to pick up the new `wake-claude.sh`
- [ ] Next real wake event arrives — if invalid, dump file appears under invalid-payloads/ and Claude sees actionable instructions instead of bare error