### PR TITLE
fix(hooks): singleton FIFO reader + stale-PR guard on review webhooks

### DIFF
--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -75,6 +75,20 @@ PROJECTS_DIR="$HOME/.claude/projects"
 # 60s is enough for the typical Stop→hook spawn latency.
 WRITE_RETRY_SECS="${WAKE_CLAUDE_RETRY_SECS:-60}"
 WRITE_TIMEOUT="${WAKE_CLAUDE_WRITE_TIMEOUT:-3}"
+# Age cutoff for event files. An event file that was DEFER'd (no live
+# consumer at producer time) stays on disk until the UserPromptSubmit
+# fallback hook drains it on the matching session's next prompt. If
+# the target session never prompts again (session died, cwd switched,
+# different repo), the file lingers forever and eventually gets
+# delivered on a completely unrelated wake-claude.sh invocation —
+# exactly what we saw with the PR #46 ci-complete event that sat on
+# disk for 61h30m before being delivered by a push that triggered
+# CI on a different PR. Files older than this threshold are dropped
+# upfront as hopelessly stale. 1h is well past the normal DEFER
+# window (WRITE_RETRY_SECS = 60s) yet still recent enough that a
+# legitimate post-stop drain can catch events that were DEFER'd just
+# before the session went to sleep.
+MAX_EVENT_AGE_SECS="${WAKE_CLAUDE_MAX_EVENT_AGE:-3600}"
 
 ###############################################################################
 # Helpers
@@ -90,11 +104,12 @@ log() { echo "[wake-claude] $*" >&2; }
 sweep_stale_session_files() {
     local f pid
     [ -d "$WAKE_DIR" ] || return 0
-    for f in "$WAKE_DIR"/.session-*.fifo "$WAKE_DIR"/.session-*.json; do
+    for f in "$WAKE_DIR"/.session-*.fifo "$WAKE_DIR"/.session-*.json "$WAKE_DIR"/.session-*.reader.lock; do
         [ -e "$f" ] || continue
         pid="${f##*/.session-}"
         pid="${pid%.fifo}"
         pid="${pid%.json}"
+        pid="${pid%.reader.lock}"
         # Numeric PID check — skip anything that does not match the pattern.
         case "$pid" in
             ''|*[!0-9]*) continue ;;
@@ -106,6 +121,41 @@ sweep_stale_session_files() {
     done
 }
 sweep_stale_session_files
+
+# Sweep event files older than MAX_EVENT_AGE_SECS. Unlike
+# sweep_stale_session_files, this runs for ALL event files in EVENTS_DIR
+# (not just this-repo files), because a long-forgotten event file from
+# any repo can eventually get picked up by a wake-claude.sh call for
+# that repo and delivered as an ancient "wake" hours or days later.
+sweep_stale_event_files() {
+    [ -d "$EVENTS_DIR" ] || return 0
+    local now_epoch ts ts_epoch age
+    now_epoch=$(date -u +%s)
+    for f in "$EVENTS_DIR"/*.json; do
+        [ -f "$f" ] || continue
+        # Prefer the timestamp recorded inside the event — it reflects
+        # when the producer generated the event. Fall back to the file
+        # mtime if the payload is unparseable or has no .timestamp field.
+        ts=""
+        if jq empty "$f" 2>/dev/null; then
+            ts=$(jq -r '.timestamp // ""' "$f" 2>/dev/null)
+        fi
+        ts_epoch=""
+        if [ -n "$ts" ]; then
+            ts_epoch=$(date -u -d "$ts" +%s 2>/dev/null || echo "")
+        fi
+        if [ -z "$ts_epoch" ]; then
+            ts_epoch=$(stat -c %Y "$f" 2>/dev/null || echo "")
+        fi
+        [ -z "$ts_epoch" ] && continue
+        age=$((now_epoch - ts_epoch))
+        if [ "$age" -gt "$MAX_EVENT_AGE_SECS" ]; then
+            log "DROP stale-on-disk (age=${age}s > MAX_EVENT_AGE_SECS=${MAX_EVENT_AGE_SECS}s): ${f##*/}"
+            rm -f "$f"
+        fi
+    done
+}
+sweep_stale_event_files
 
 [ -d "$EVENTS_DIR" ] || exit 0
 

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -65,23 +65,89 @@ fi
 
 FIFO="$WAKE_DIR/.session-${CLAUDE_PID}.fifo"
 MANIFEST="$WAKE_DIR/.session-${CLAUDE_PID}.json"
+LOCKFILE="$WAKE_DIR/.session-${CLAUDE_PID}.reader.lock"
 
-# NOTE: there is no singleton check. Multiple wake-on-event.sh instances per
-# session are intentional: Claude Code spawns a new hook on every Stop event,
-# and old instances stay blocked on `cat $FIFO` until either (a) they receive
-# an event and exit 2, or (b) their 600s timeout expires. Multiple readers
-# blocked on the same FIFO are a feature — when wake-claude.sh writes one
-# event, the kernel atomically delivers it to exactly one reader; the others
-# stay alive and act as backup readers for subsequent events. This makes the
-# wake mechanism more resilient to bursts.
+###############################################################################
+# Singleton reader enforcement
+###############################################################################
+#
+# Only ONE wake-on-event.sh instance may block on the FIFO at a time per
+# Claude session. A previous iteration of this script claimed that multiple
+# concurrent readers were "a feature" — that was WRONG.
+#
+# The failure mode: bash's `read -r` builtin reads from its input FD one
+# BYTE at a time (it has to scan for the delimiter byte-by-byte). When two
+# processes block simultaneously in `read -r` on the same FIFO, the kernel
+# delivers one byte of an atomic write to one reader, the next byte to the
+# other, and so on. The result is that each reader ends up with every OTHER
+# byte of the payload — "garbled" NDJSON that fails `jq empty` parse. When
+# the first reader hits a newline and exits, the second inherits the rest
+# of the stream, so its buffer ends up as (every-other-byte of payload A) +
+# (clean payload B). This exact pattern was observed repeatedly in
+# ~/.config/claude-channels/invalid-payloads/*.txt.
+#
+# Fix: a PID-based lockfile ensures at most one reader per CLAUDE_PID.
+# New spawns that find a live reader step aside (exit 0) and leave the
+# existing reader in charge. If the old reader exited ungracefully and
+# left a stale lock, the new spawn detects that via `kill -0` + cmdline
+# re-verification (PID reuse protection) and takes over.
+#
+# Claim is atomic via `set -C` (noclobber) — the kernel guarantees that
+# two concurrent spawns cannot both succeed at creating the same file.
+
+claim_lock() {
+    (set -C; echo "$$" > "$LOCKFILE") 2>/dev/null
+}
+
+release_lock() {
+    # Only release if we still own the lock. Avoids a rm of a lock that
+    # was stolen from us by PID reuse or a rogue overwrite.
+    local owner
+    owner=$(cat "$LOCKFILE" 2>/dev/null)
+    if [ "$owner" = "$$" ]; then
+        rm -f "$LOCKFILE"
+    fi
+}
+
+if ! claim_lock; then
+    # Lock exists — inspect the current owner.
+    old_pid=$(cat "$LOCKFILE" 2>/dev/null)
+    if [ -n "$old_pid" ] && [ "$old_pid" != "$$" ] && kill -0 "$old_pid" 2>/dev/null; then
+        # Owner is alive. Verify it is actually wake-on-event.sh (not a
+        # PID-reuse victim that happens to have the same numeric PID).
+        old_cmdline=$(tr '\0' ' ' < "/proc/$old_pid/cmdline" 2>/dev/null)
+        case "$old_cmdline" in
+            *wake-on-event.sh*)
+                # Another live reader owns the FIFO. Step aside without
+                # touching the FIFO, the manifest, or the lock — the
+                # existing reader is still doing its job.
+                exit 0
+                ;;
+        esac
+    fi
+    # Stale lock (owner is dead, or was never wake-on-event.sh). Drop it
+    # and try once more. If a concurrent spawn beat us, exit without
+    # racing — there is always going to be a live reader either way.
+    rm -f "$LOCKFILE"
+    if ! claim_lock; then
+        exit 0
+    fi
+fi
 
 ###############################################################################
 # Cleanup on real exit (not on exit 2 — Claude Code respawns the hook then)
 ###############################################################################
 
 cleanup() {
-    # Only purge if the parent Claude process is dead. exit 2 keeps the
-    # session alive and we want the FIFO preserved for the next spawn.
+    # Always release the reader lock so the next spawn can claim it.
+    # Without this, after `exit 2` the next Stop-hook spawn would see a
+    # stale lock with our own (dead) PID and there would be no reader
+    # until the PID-reuse protection kicks in.
+    release_lock
+
+    # Only purge FIFO/manifest if the parent Claude process is dead.
+    # exit 2 keeps the session alive and we want the FIFO preserved for
+    # the next spawn.
     if ! kill -0 "$CLAUDE_PID" 2>/dev/null; then
         rm -f "$FIFO" "$MANIFEST"
     fi

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -92,11 +92,27 @@ LOCKFILE="$WAKE_DIR/.session-${CLAUDE_PID}.reader.lock"
 # left a stale lock, the new spawn detects that via `kill -0` + cmdline
 # re-verification (PID reuse protection) and takes over.
 #
-# Claim is atomic via `set -C` (noclobber) — the kernel guarantees that
-# two concurrent spawns cannot both succeed at creating the same file.
+# Claim is atomic via hard-link: we write our PID to a per-process temp
+# file FIRST, then `ln` it into place as $LOCKFILE. `ln` fails with EEXIST
+# if $LOCKFILE already exists, so at most one spawn can succeed, and any
+# reader that observes $LOCKFILE sees a fully populated PID — never an
+# empty file in the open-but-not-yet-written window that a bare
+# `(set -C; echo > LOCKFILE)` would expose. Addresses the race Copilot
+# flagged on PR #47: the previous noclobber-based claim_lock let a
+# concurrent spawn `cat` the file between open and write, see empty
+# contents, treat it as stale, rm it, and claim its own — two owners
+# and byte-race re-emerged.
 
 claim_lock() {
-    (set -C; echo "$$" > "$LOCKFILE") 2>/dev/null
+    local tmp_lock="${LOCKFILE}.$$.tmp"
+    # Write PID to temp first so the final link target is always populated.
+    printf '%s\n' "$$" > "$tmp_lock" 2>/dev/null || return 1
+    if ln "$tmp_lock" "$LOCKFILE" 2>/dev/null; then
+        rm -f "$tmp_lock"
+        return 0
+    fi
+    rm -f "$tmp_lock"
+    return 1
 }
 
 release_lock() {
@@ -108,6 +124,25 @@ release_lock() {
         rm -f "$LOCKFILE"
     fi
 }
+
+# Defense against a lockfile path that somehow exists but is NOT a regular
+# file (directory, FIFO, symlink to missing target, etc). `rm -f` silently
+# skips directories, which would otherwise make claim_lock fail forever
+# and leave the session with no reader. Log loudly, attempt targeted
+# cleanup (rmdir for an empty dir, rm -f for everything else), and give
+# up only if the path still exists afterwards. Copilot review on PR #47.
+if [ -e "$LOCKFILE" ] && [ ! -f "$LOCKFILE" ]; then
+    echo "[wake-on-event] $LOCKFILE exists but is not a regular file — attempting cleanup" >&2
+    if [ -d "$LOCKFILE" ]; then
+        rmdir "$LOCKFILE" 2>/dev/null
+    else
+        rm -f "$LOCKFILE" 2>/dev/null
+    fi
+    if [ -e "$LOCKFILE" ]; then
+        echo "[wake-on-event] failed to clean up $LOCKFILE — exiting (session will have no reader until the path is fixed manually)" >&2
+        exit 0
+    fi
+fi
 
 if ! claim_lock; then
     # Lock exists — inspect the current owner.

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -188,6 +188,27 @@ class WebhookHandler(BaseHTTPRequestHandler):
         pr_url = pr.get("html_url", "")
         head_sha = pr.get("head", {}).get("sha", "unknown")[:7]
 
+        # Stale PR guard — skip review events for PRs that are already merged
+        # or closed. Copilot reviews can arrive minutes after merge (Copilot
+        # analyses the PR in the background, and its review post races with
+        # any fast post-merge action). Waking Claude for a MERGED PR forces
+        # the session to verify + classify as "stale" every time — noise
+        # that this guard eliminates at the producer. See analysis in
+        # ~/.config/claude-channels/wake-feedback.md entries classified
+        # "stale" during 2026-04-08 → 2026-04-11. The pull_request object
+        # in a pull_request_review webhook payload carries the live state
+        # and merged flag, so no extra API call is needed.
+        pr_state = pr.get("state", "open")
+        pr_merged = bool(pr.get("merged"))
+        if pr_merged or pr_state != "open":
+            reason = "merged" if pr_merged else pr_state
+            print(
+                f"[webhook-receiver] SKIP review for {repo_name} PR #{pr_number} "
+                f"(reviewer: {reviewer}): PR is already {reason} — not waking",
+                file=sys.stderr,
+            )
+            return
+
         # Count review comments
         comment_count = 0
         review_id = review.get("id")


### PR DESCRIPTION
<!-- claude-session: 2a0c99e5-6861-4ccd-8223-08ab7de19ab8 -->

## Summary

Three distinct wake-system bugs producing bogus / late events, all observed in `~/.config/claude-channels/wake-feedback.md` and `invalid-payloads/` during 2026-04-11 debugging:

1. **Garbled NDJSON from concurrent FIFO readers** (`wake-on-event.sh`) — multiple `wake-on-event.sh` instances were allowed to block on the same FIFO simultaneously, each doing bash `read -r` which reads one byte at a time. The kernel handed out alternating bytes of every atomic producer write, so each reader ended up with every OTHER byte of the payload. Three dumps in `~/.config/claude-channels/invalid-payloads/` from 2026-04-11 all show the same signature: garbled-A prefix (even-indexed bytes of payload A) followed by clean payload B.

2. **Stale `code-review-complete` wake events for already-merged PRs** (`webhook-receiver.py`) — Copilot reviews can arrive minutes after a PR is merged; the producer was waking Claude regardless, forcing every session to verify PR state and log the event as `stale`.

3. **Ancient event files delivered as wake events** (`wake-claude.sh`) — during this same debug session, a PR #46 ci-complete event from 2026-04-08T21:07:25Z was delivered with EVENT AGE 61h30m. The DEFER'd-on-disk file sat for 61 hours until an unrelated `wake-claude.sh` invocation for PR #47 on the same repo processed it as a legitimate pending event. The existing DEFER fallback (bug 35) assumed the target session would eventually prompt and drain via UserPromptSubmit — it does not handle the case where that never happens.

## Fix

**Singleton FIFO reader** — PID-based lockfile at `$WAKE_DIR/.session-$CLAUDE_PID.reader.lock`, claimed atomically via `set -C` (noclobber). On spawn, if the lock is held by a live `wake-on-event.sh` for the same Claude session, exit immediately. If the lock is stale (owner dead, or PID reuse to a non-`wake-on-event.sh` process), drop and reclaim. Lock released on EVERY exit — including `exit 2` after successful event delivery — so the next Stop-hook spawn can claim it.

**Stale-PR guard** — `_handle_review` reads `pr.merged` and `pr.state` from the webhook payload itself (no extra API call) and skips if the PR is already merged or closed.

**Age-based event-file GC** — `sweep_stale_event_files()` runs at the top of every `wake-claude.sh` invocation and drops any file in `EVENTS_DIR` whose `.timestamp` (fallback: mtime) is older than `MAX_EVENT_AGE_SECS` (default 3600s, configurable via `WAKE_CLAUDE_MAX_EVENT_AGE`). This is well past the normal DEFER retry window (`WRITE_RETRY_SECS = 60s`) yet short enough that session-on-lunch-break behavior is preserved. `sweep_stale_session_files` now also cleans up the new `.reader.lock` files for dead Claude PIDs.

## Root cause — byte-race

Previous comment in `wake-on-event.sh` claimed multiple readers were "a feature" because "the kernel atomically delivers to exactly one reader". True for the kernel's `write(fd, buf, N)` → `read(fd, buf, N)` pair — but bash's `read -r` doesn't do one large read. It calls `read(fd, &c, 1)` in a loop to scan for the delimiter byte. Two concurrent byte-at-a-time readers race for individual bytes, producing the observed every-other-byte pattern.

## Test plan

- [x] Syntax: `bash -n` on both shell files + `python3 ast.parse` on webhook-receiver.py
- [x] Singleton lock isolated: 4 cases — fresh claim, double-claim rejection, claim-after-release, foreign-lock ownership
- [x] Stale event sweep isolated: old-dated file dropped, new-dated file kept
- [ ] Manual: install via `./hooks/install.sh`, trigger two rapid wake events, verify no new `invalid-payloads/` dumps
- [ ] Field test: monitor `~/.config/claude-channels/wake-feedback.md` for several days — expect zero new `garbled` and sharply reduced `stale` classifications

## Linked incidents

- `~/.config/claude-channels/invalid-payloads/20260411T10*-process_event.txt` (3 files) — garbled byte-race dumps
- `~/.config/claude-channels/wake-feedback.md` entries 2026-04-11 10:18:18Z (garbled), 10:19:31Z (stale), 10:25:20Z (garbled), 12:37 (stale 61h30m old ci-complete for PR #46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)