### PR TITLE
fix(hooks): reader-death recovery — stale lock cleanup + signal traps

### DIFF
--- a/hooks/check-deploy-status.sh
+++ b/hooks/check-deploy-status.sh
@@ -40,16 +40,25 @@ _find_claude_pid() {
 }
 
 _clean_stale_reader_lock() {
-    local cpid lock_file lock_owner
+    local cpid lock_file lock_owner current_lock_owner
     cpid=$(_find_claude_pid)
     [ -z "$cpid" ] && return 0
     lock_file="$WAKE_DIR/.session-${cpid}.reader.lock"
     [ -f "$lock_file" ] || return 0
     lock_owner=$(cat "$lock_file" 2>/dev/null)
     [ -z "$lock_owner" ] && return 0
+    # Numeric PID validation — skip corrupt content.
+    case "$lock_owner" in ''|*[!0-9]*) return 0 ;; esac
     if ! kill -0 "$lock_owner" 2>/dev/null; then
-        rm -f "$lock_file"
-        echo "[check-deploy-status] Cleaned stale reader.lock for session PID $cpid (was held by dead PID $lock_owner)" >&2
+        # TOCTOU guard: re-read the lock before deleting. Between our
+        # first read and now, a new wake-on-event.sh could have removed
+        # the stale lock and claimed a new one. Deleting the NEW lock
+        # would break the singleton guarantee. Copilot review on PR #48.
+        current_lock_owner=$(cat "$lock_file" 2>/dev/null) || return 0
+        if [ "$current_lock_owner" = "$lock_owner" ]; then
+            rm -f "$lock_file"
+            echo "[check-deploy-status] Cleaned stale reader.lock for session PID $cpid (was held by dead PID $lock_owner)" >&2
+        fi
     fi
 }
 _clean_stale_reader_lock

--- a/hooks/check-deploy-status.sh
+++ b/hooks/check-deploy-status.sh
@@ -5,6 +5,54 @@
 # and deletes the file so it's only shown once.
 
 EVENTS_DIR="$HOME/.config/claude-channels/deploy-events"
+WAKE_DIR="/tmp/claude-wake"
+
+###############################################################################
+# Recovery: clean stale reader.lock for this session
+###############################################################################
+#
+# If our session's wake-on-event.sh reader died without releasing its lock
+# (e.g. SIGKILL, OOM), the next Stop-hook spawn will see the stale lock and
+# claim it — but only when a Stop event fires. If the session is idle
+# (waiting for user input or a wake event), NO Stop fires and the session
+# goes "deaf": wake-claude.sh DEFERs events to disk, no reader picks them
+# up, the user sees nothing. By cleaning the stale lock HERE (on every
+# UserPromptSubmit), we ensure the user's NEXT prompt triggers a model
+# response → Stop → new reader spawn → FIFO comes back to life.
+#
+# This is the last line of defense against the deadlock:
+#   user waits for wake → reader is dead → wake DEFERs → user keeps waiting
+# By running on UserPromptSubmit (which fires when the user breaks the
+# deadlock by typing anything), we restore the reader pipeline.
+
+_find_claude_pid() {
+    local pid=$PPID i=0
+    while [ "$pid" -gt 1 ] && [ "$i" -lt 10 ]; do
+        local comm
+        comm=$(cat "/proc/$pid/comm" 2>/dev/null) || break
+        if [ "$comm" = "claude" ]; then
+            echo "$pid"
+            return 0
+        fi
+        pid=$(awk '{print $4}' "/proc/$pid/stat" 2>/dev/null) || break
+        i=$((i + 1))
+    done
+}
+
+_clean_stale_reader_lock() {
+    local cpid lock_file lock_owner
+    cpid=$(_find_claude_pid)
+    [ -z "$cpid" ] && return 0
+    lock_file="$WAKE_DIR/.session-${cpid}.reader.lock"
+    [ -f "$lock_file" ] || return 0
+    lock_owner=$(cat "$lock_file" 2>/dev/null)
+    [ -z "$lock_owner" ] && return 0
+    if ! kill -0 "$lock_owner" 2>/dev/null; then
+        rm -f "$lock_file"
+        echo "[check-deploy-status] Cleaned stale reader.lock for session PID $cpid (was held by dead PID $lock_owner)" >&2
+    fi
+}
+_clean_stale_reader_lock
 
 # Check if directory exists
 if [ ! -d "$EVENTS_DIR" ]; then

--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -517,6 +517,25 @@ process_event_file() {
         # Without this fallback, a wake event arriving while no hook is
         # currently in `read` is silently lost after WRITE_RETRY_SECS.
         log "DEFER ${event_file##*/} → PID $target_pid (PR=${pr_num:-?}) — file kept for UserPromptSubmit fallback"
+
+        # Recovery: if the FIFO write failed because no reader is active,
+        # the reader.lock may be held by a dead process. Clean it up NOW
+        # so the NEXT Stop-hook spawn for this Claude session is not
+        # blocked by a stale lock. Without this, the session goes "deaf"
+        # indefinitely: wake-claude.sh DEFERs, but the next hook spawn
+        # sees a live-looking lock and exits 0, leaving no reader.
+        # Observed in the field on 2026-04-13: PID 11079 (Olbrasoft/cr)
+        # had reader.lock held by dead PID 627450; two events sat on disk
+        # for 15+ minutes with no path to delivery.
+        local reader_lock="$WAKE_DIR/.session-${target_pid}.reader.lock"
+        if [ -f "$reader_lock" ]; then
+            local lock_owner
+            lock_owner=$(cat "$reader_lock" 2>/dev/null)
+            if [ -n "$lock_owner" ] && ! kill -0 "$lock_owner" 2>/dev/null; then
+                log "Cleaning stale reader.lock for PID $target_pid (held by dead $lock_owner)"
+                rm -f "$reader_lock"
+            fi
+        fi
     fi
 }
 

--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -531,9 +531,22 @@ process_event_file() {
         if [ -f "$reader_lock" ]; then
             local lock_owner
             lock_owner=$(cat "$reader_lock" 2>/dev/null)
+            # Numeric PID validation — skip non-numeric content (corrupt lock).
+            case "$lock_owner" in ''|*[!0-9]*) lock_owner="" ;; esac
             if [ -n "$lock_owner" ] && ! kill -0 "$lock_owner" 2>/dev/null; then
-                log "Cleaning stale reader.lock for PID $target_pid (held by dead $lock_owner)"
-                rm -f "$reader_lock"
+                # TOCTOU guard: re-read the lock before deleting. Between
+                # our first read and now, a new wake-on-event.sh could have
+                # removed the stale lock and claimed a new one. Deleting
+                # the NEW lock would re-open concurrent readers.
+                # Copilot review on PR #48.
+                local current_lock_owner
+                current_lock_owner=$(cat "$reader_lock" 2>/dev/null)
+                if [ "$current_lock_owner" = "$lock_owner" ]; then
+                    log "Cleaning stale reader.lock for PID $target_pid (held by dead $lock_owner)"
+                    rm -f "$reader_lock"
+                else
+                    log "Skip stale reader.lock cleanup for PID $target_pid; lock changed during validation"
+                fi
             fi
         fi
     fi

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -187,12 +187,18 @@ cleanup() {
         rm -f "$FIFO" "$MANIFEST"
     fi
 }
-# Trap EXIT for normal exits AND trappable signals. SIGKILL (kill -9)
-# cannot be trapped — that is the ONE case where a stale lock survives.
-# All other common termination signals (SIGTERM from systemd-user or
-# Claude Code cleanup, SIGHUP from terminal close, SIGINT from Ctrl-C)
-# now trigger lock release, greatly reducing stale-lock occurrences.
-trap cleanup EXIT SIGTERM SIGHUP SIGINT
+# EXIT trap for normal exits (exit 0, exit 2).
+trap cleanup EXIT
+# Signal traps for SIGTERM/SIGHUP/SIGINT must explicitly exit after
+# cleanup. In bash, trapping a signal REPLACES the default termination
+# behavior — without the explicit `exit`, the script would continue its
+# FIFO read loop WITHOUT holding the lock (cleanup released it),
+# potentially allowing a concurrent reader and breaking the singleton
+# guarantee. Copilot review on PR #48.
+# The EXIT trap also fires when we `exit 0` here, calling cleanup a
+# second time — this is safe because release_lock is idempotent (it
+# re-reads the lockfile and only removes it if we still own it).
+trap 'cleanup; exit 0' SIGTERM SIGHUP SIGINT
 
 ###############################################################################
 # Create FIFO + manifest if missing (idempotent across hook spawns)

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -187,7 +187,12 @@ cleanup() {
         rm -f "$FIFO" "$MANIFEST"
     fi
 }
-trap cleanup EXIT
+# Trap EXIT for normal exits AND trappable signals. SIGKILL (kill -9)
+# cannot be trapped — that is the ONE case where a stale lock survives.
+# All other common termination signals (SIGTERM from systemd-user or
+# Claude Code cleanup, SIGHUP from terminal close, SIGINT from Ctrl-C)
+# now trigger lock release, greatly reducing stale-lock occurrences.
+trap cleanup EXIT SIGTERM SIGHUP SIGINT
 
 ###############################################################################
 # Create FIFO + manifest if missing (idempotent across hook spawns)


### PR DESCRIPTION
<!-- claude-session: 2a0c99e5-6861-4ccd-8223-08ab7de19ab8 -->

## Summary

Fixes the reader-death deadlock observed on 2026-04-13 (Olbrasoft/cr PR #406): wake-on-event.sh reader died without releasing its lock, session was idle → events sat on disk indefinitely.

## The deadlock

```
user waits for wake → reader is dead → wake-claude.sh DEFERs →
events on disk → no Stop fires → no new reader → user keeps waiting
```

Two events (CI failure + Copilot review with 13 comments) for PR #406 sat on disk for 15+ minutes.

## Fix (three-pronged)

| Where | What | Why |
|---|---|---|
| `wake-on-event.sh` | Trap SIGTERM/SIGHUP/SIGINT (not just EXIT) | Most termination signals now release the lock cleanly |
| `wake-claude.sh` | On DEFER, clean stale reader.lock (dead owner) | Next Stop-hook spawn gets a clean lock → fresh reader |
| `check-deploy-status.sh` | On UserPromptSubmit, clean stale reader.lock | Deadlock-breaker: user types → lock cleaned → model responds → Stop → reader spawns |

**Only SIGKILL remains untrappable** — that's the one case where a stale lock survives. But the DEFER + UserPromptSubmit cleanup paths catch it on the next interaction.

## Test plan

- [x] Syntax: `bash -n` on all three scripts
- [ ] Field test: kill a wake-on-event.sh reader with `kill -15`, verify lock is released
- [ ] Field test: kill with `kill -9`, verify lock is cleaned on next UserPromptSubmit
- [ ] Field test: verify events are delivered on next user interaction after reader death

🤖 Generated with [Claude Code](https://claude.com/claude-code)
