### PR TITLE
fix(hooks): merged-PR guard for CI events — producer AND delivery side

### DIFF
--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -96,6 +96,54 @@ MAX_EVENT_AGE_SECS="${WAKE_CLAUDE_MAX_EVENT_AGE:-3600}"
 
 log() { echo "[wake-claude] $*" >&2; }
 
+# Per-invocation cache of PR state/merged lookups. A single wake-claude.sh
+# run can process multiple event files for the SAME PR (batched pushes,
+# multi-event repos on busy days). Without the cache, the delivery-side
+# stale-PR guard would run `gh pr view` once per file, producing
+# redundant API calls and extra rate-limit pressure. Cached value
+# format: "<STATE>|<MERGED_BOOL>" (e.g. "OPEN|false" or "MERGED|true").
+# Cache entries persist only for the duration of this script run — the
+# next invocation re-fetches, so a PR merged since last run is picked
+# up promptly. Copilot review on PR #49.
+declare -A PR_STATE_CACHE
+PR_STATE_RESULT=""
+
+# Query PR state once per pr_num. Populates PR_STATE_CACHE[pr_num] and
+# sets the global PR_STATE_RESULT to "<STATE>|<MERGED_BOOL>" (or "|" on
+# API error; empty when pr_num itself is empty).
+#
+# IMPORTANT: we do NOT return the value via stdout. Command substitution
+# (`$(pr_state_cached ...)`) runs the function in a SUBSHELL, and any
+# updates to PR_STATE_CACHE inside the subshell are discarded on exit —
+# the cache never persists and every call re-runs `gh pr view`.
+# Caching must happen in the caller's shell, so we mutate the parent
+# shell via PR_STATE_RESULT and the associative array by calling the
+# function directly (no `$(...)` wrapping). Found during isolated
+# 5-event caching test post-Copilot-review on PR #49.
+pr_state_cached() {
+    local pn="$1"
+    PR_STATE_RESULT=""
+    [ -z "$pn" ] && return 0
+    if [ -n "${PR_STATE_CACHE[$pn]:-}" ]; then
+        PR_STATE_RESULT="${PR_STATE_CACHE[$pn]}"
+        return 0
+    fi
+    local json state merged
+    json=$(timeout 10 gh pr view "$pn" --repo "$REPO_FULL" --json state,mergedAt 2>/dev/null)
+    if [ -z "$json" ]; then
+        # Cache the failure too (as "|") so a second event file for the
+        # same PR does not re-try — failure is usually auth/rate-limit,
+        # and retrying in-loop just piles up more failures.
+        PR_STATE_CACHE[$pn]="|"
+        PR_STATE_RESULT="|"
+        return 0
+    fi
+    state=$(echo "$json" | jq -r '.state // ""')
+    merged=$(echo "$json" | jq -r 'if .mergedAt then "true" else "false" end')
+    PR_STATE_CACHE[$pn]="$state|$merged"
+    PR_STATE_RESULT="$state|$merged"
+}
+
 # Sweep stale per-session FIFOs and manifests for dead Claude PIDs.
 # Defined and called BEFORE the EVENTS_DIR existence check (#36 follow-up
 # from Copilot review on PR #38) so that the sweep runs even when there
@@ -473,11 +521,16 @@ process_event_file() {
     # VA#943) all fired for PRs that were merged between event creation
     # and session consumption.
     if [ -n "$pr_num" ]; then
-        local pr_state_json pr_state pr_merged
-        pr_state_json=$(timeout 10 gh pr view "$pr_num" --repo "$REPO_FULL" --json state,mergedAt 2>/dev/null)
-        if [ -n "$pr_state_json" ]; then
-            pr_state=$(echo "$pr_state_json" | jq -r '.state // ""')
-            pr_merged=$(echo "$pr_state_json" | jq -r 'if .mergedAt then "true" else "false" end')
+        # Call directly (NOT in $(...)) so cache mutations persist —
+        # result is in $PR_STATE_RESULT. Format is "STATE|MERGED" or
+        # "|" on API failure. Fail-open: deliver anyway rather than risk
+        # losing a legitimate wake.
+        pr_state_cached "$pr_num"
+        local combined="$PR_STATE_RESULT"
+        if [ -n "$combined" ] && [ "$combined" != "|" ]; then
+            local pr_state pr_merged
+            pr_state="${combined%%|*}"
+            pr_merged="${combined##*|}"
             if [ "$pr_merged" = "true" ] || { [ -n "$pr_state" ] && [ "$pr_state" != "OPEN" ]; }; then
                 local reason="$pr_state"
                 [ "$pr_merged" = "true" ] && reason="MERGED"
@@ -486,8 +539,6 @@ process_event_file() {
                 return
             fi
         fi
-        # If the gh call failed (network, auth, rate limit), fall through
-        # and deliver anyway — better a noisy wake than a lost one.
     fi
 
     # Find target PID — PRIMARY: session UUID from PR body marker

--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -455,6 +455,41 @@ process_event_file() {
         fi
     fi
 
+    # Delivery-side stale-PR guard. An event that was valid at producer
+    # time can become stale before we actually deliver it:
+    #   - Producer wrote event at T=0 while PR was OPEN.
+    #   - wake-claude.sh DEFER'd it (no reader on FIFO at T=0).
+    #   - User merged the PR at T=2m.
+    #   - At T=5m a new wake-claude.sh invocation for the same repo picks
+    #     up the DEFER'd file and tries to deliver — but the PR is now
+    #     MERGED and delivering produces pure noise (the consumer will
+    #     verify state, classify as stale, log a feedback entry, and
+    #     move on).
+    # Dropping here instead of delivering eliminates that noise.
+    # Producer-side (webhook-receiver.py) already guards against the
+    # already-merged case at event CREATION time; this is the paired
+    # guard at event DELIVERY time. Observed 2026-04-15 on Olbrasoft/cr:
+    # 4 back-to-back stale ci-complete events (PRs #427, #429 ×2, #431,
+    # VA#943) all fired for PRs that were merged between event creation
+    # and session consumption.
+    if [ -n "$pr_num" ]; then
+        local pr_state_json pr_state pr_merged
+        pr_state_json=$(timeout 10 gh pr view "$pr_num" --repo "$REPO_FULL" --json state,mergedAt 2>/dev/null)
+        if [ -n "$pr_state_json" ]; then
+            pr_state=$(echo "$pr_state_json" | jq -r '.state // ""')
+            pr_merged=$(echo "$pr_state_json" | jq -r 'if .mergedAt then "true" else "false" end')
+            if [ "$pr_merged" = "true" ] || { [ -n "$pr_state" ] && [ "$pr_state" != "OPEN" ]; }; then
+                local reason="$pr_state"
+                [ "$pr_merged" = "true" ] && reason="MERGED"
+                log "DROP ${event_file##*/} — PR #$pr_num is already $reason (stale at delivery, not waking)"
+                rm -f "$event_file"
+                return
+            fi
+        fi
+        # If the gh call failed (network, auth, rate limit), fall through
+        # and deliver anyway — better a noisy wake than a lost one.
+    fi
+
     # Find target PID — PRIMARY: session UUID from PR body marker
     #                  FALLBACK: strict cwd matching (exactly one Claude on repo)
     local target_pid=""

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -302,6 +302,29 @@ class WebhookHandler(BaseHTTPRequestHandler):
                   file=sys.stderr)
             return
 
+        # Stale-PR guard — skip CI events for PRs that are already merged
+        # or closed. GitHub re-fires check_suite events during the final
+        # merge handshake, and GitHub Actions runners can complete minutes
+        # after a PR was squash-merged with a different head SHA. Waking
+        # Claude for a MERGED PR forces every session to verify state and
+        # classify as "stale", exactly the noise this guard eliminates.
+        # Observed 2026-04-15 19:45 on Olbrasoft/cr: 4 back-to-back stale
+        # ci-complete events for PRs #427, #429 (duplicate), #431,
+        # VA#943 — all already merged at event arrival. PR #47 shipped
+        # the same guard for pull_request_review but missed check_suite;
+        # this commit closes that gap.
+        pr_state = (agg.get("state") or "open").lower()
+        pr_merged = bool(agg.get("merged"))
+        if pr_merged or pr_state != "open":
+            reason = "merged" if pr_merged else pr_state
+            print(
+                f"[webhook-receiver] SKIP check_suite for {repo_name} "
+                f"PR #{pr_number} ({head_sha_short}): PR is already "
+                f"{reason} — not waking",
+                file=sys.stderr,
+            )
+            return
+
         if not agg["all_terminal"]:
             print(f"[webhook-receiver] PR #{pr_number}: {agg['pending']} check(s) still pending, "
                   f"deferring wake until all complete",
@@ -384,7 +407,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
         _wake(repo_name, pr_branch)
 
     def _aggregate_pr_checks(self, repo_name, pr_number):
-        """Query `gh pr view --json statusCheckRollup` for the aggregate status of all checks on a PR.
+        """Query `gh pr view` for the aggregate check status AND the PR's
+        merged/state flags. Both are fetched in one call so the stale-PR
+        guard does not add an extra API round-trip.
 
         Returns a dict with keys:
           all_terminal (bool): True if every check is in a terminal state
@@ -393,18 +418,22 @@ class WebhookHandler(BaseHTTPRequestHandler):
           success  (int): count of SUCCESS checks
           failure  (int): count of FAILURE checks
           skipped  (int): count of SKIPPED checks
+          state    (str): PR state — "OPEN" / "CLOSED" / "MERGED"
+          merged   (bool): whether the PR was merged
         Returns None on gh CLI error.
         """
         try:
             result = subprocess.run(
                 ["gh", "pr", "view", str(pr_number), "--repo", repo_name,
-                 "--json", "statusCheckRollup"],
+                 "--json", "statusCheckRollup,state,mergedAt"],
                 capture_output=True, text=True, timeout=10
             )
             if result.returncode != 0:
                 return None
             data = json.loads(result.stdout)
             checks = data.get("statusCheckRollup", []) or []
+            pr_state = data.get("state") or ""
+            pr_merged = bool(data.get("mergedAt"))
         except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
             return None
 
@@ -444,6 +473,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
             "success": success,
             "failure": failure,
             "skipped": skipped,
+            "state": pr_state,
+            "merged": pr_merged,
         }
 
     def log_message(self, format, *args):

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -297,8 +297,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # to wait for, OR there may still be checks in progress.
         agg = self._aggregate_pr_checks(repo_name, pr_number)
         if agg is None:
-            print(f"[webhook-receiver] PR #{pr_number}: gh pr view --json statusCheckRollup "
-                  f"failed, skipping wake",
+            print(f"[webhook-receiver] PR #{pr_number}: gh pr view "
+                  f"(statusCheckRollup,state,mergedAt) failed, skipping wake",
                   file=sys.stderr)
             return
 


### PR DESCRIPTION
<!-- claude-session: 2a0c99e5-6861-4ccd-8223-08ab7de19ab8 -->

## Summary

Fixes a gap left by PR #47: the merged-PR guard only covered `pull_request_review` webhook events, not `check_suite` (CI). And it only ran on the producer side — DEFER'd events that became stale between producer and delivery still got delivered as stale wakes.

## The observation

From `~/.config/claude-channels/wake-feedback.md` (2026-04-15 19:45 block, all on Olbrasoft/cr):

```
19:45:12 — ci-complete #429 stale "already squash-merged at 19:44"
19:45:26 — ci-complete #429 stale (DUPLICATE)
19:45:43 — ci-complete #431 stale "already merged at 19:43"
19:45:33 — ci-complete VA #943 stale "PR already merged"
```

Four back-to-back stale CI events. The `pull_request_review` guard shipped in PR #47 would have caught these IF they were review events — but they're check_suite events and took a different code path.

## Fix

### 1. Producer side — `webhook-receiver.py` `_handle_check_suite`

Extend the existing `gh pr view` call (already used for `statusCheckRollup`) to ALSO fetch `state` and `mergedAt`. Zero extra API round-trips. Skip with a diagnostic log if the PR is merged or `state != "OPEN"`.

### 2. Delivery side — `wake-claude.sh` `process_event_file`

After extracting `pr_num`, call `gh pr view --json state,mergedAt`. If merged/closed, DROP the event file with a log line. Catches events where the producer was correct at creation time but the PR was merged before delivery (e.g. DEFER'd on disk while user merged).

**Fail-open on API errors**: if `gh pr view` fails (network, auth, rate limit), deliver anyway — a noisy wake beats a lost one.

## Why logging matters (and what's new)

The user asked specifically: "we said we'd have logging so it's clear what happened and can be fixed." This PR emits explicit stderr lines at both guard points:

```
[webhook-receiver] SKIP check_suite for Olbrasoft/cr PR #429 (953d943): PR is already merged — not waking
[wake-claude] DROP <event-file> — PR #429 is already MERGED (stale at delivery, not waking)
```

Both land in `journalctl --user -u gh-webhook-forward.service` (producer) and the systemd / terminal stderr of whichever call site invoked `wake-claude.sh` (delivery). So next time a session still sees stale events, the diagnostic starts from logs, not guesswork.

## Test plan

- [x] Syntax: `bash -n hooks/wake-claude.sh` + `python3 ast.parse` on webhook-receiver.py
- [x] Isolated: 5-case bash test of the merged-guard logic (merged, open, closed, empty API response, state-only-no-mergedAt)
- [ ] Field: monitor `~/.config/claude-channels/wake-feedback.md` over the next day — expect sharp decrease in `stale` classifications for CI events

## Linked

- PR #47 shipped the sibling guard for `pull_request_review` — this closes the symmetric gap for `check_suite`
- wake-feedback.md 2026-04-15 19:41-19:45 block — the incident log that motivated this
- Event file still on disk at PR creation time: `~/.config/claude-channels/deploy-events/Olbrasoft-cr-ci-428-4d6af460*.json` (PR #428 merged at 19:43:14Z, event written at 19:39:25Z — classic pre-merge-valid / post-merge-stale case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
