### PR TITLE
fix(hooks): scope delivery-side merged-PR guard to PRE-MERGE events only

### DIFF
--- a/hooks/wake-claude.sh
+++ b/hooks/wake-claude.sh
@@ -488,8 +488,9 @@ process_event_file() {
         return
     fi
 
-    # Extract optional PR number from event
-    local pr_num
+    # Extract event type and optional PR number
+    local event_type pr_num
+    event_type=$(echo "$event_data" | jq -r '.event // empty')
     pr_num=$(echo "$event_data" | jq -r '.prNumber // empty')
 
     if [ -z "$pr_num" ]; then
@@ -502,6 +503,25 @@ process_event_file() {
             case "$pr_num" in ''|*[!0-9]*) pr_num="" ;; esac
         fi
     fi
+
+    # Delivery-side stale-PR guard applies ONLY to pre-merge events
+    # (ci-complete, code-review-complete). Post-merge events
+    # (deploy-complete, verify-complete) run BY DESIGN after a merge;
+    # for them, "PR is merged" is the expected state, not staleness.
+    # Applying the merged-PR check to a deploy-complete event for the
+    # PR's merge commit wrongly drops legitimate deploy notifications —
+    # observed 2026-04-15 on Olbrasoft/VirtualAssistant PR #945:
+    # deploy workflow ran successfully on d0f3b01 (merge commit),
+    # wrote the event file, then wake-claude.sh derived pr_num=945
+    # from the merge commit, saw "PR #945 MERGED", and DROPped the
+    # event — leaving the session indefinitely waiting for a deploy
+    # wake that never arrived. Regression introduced by the guard in
+    # PR #49, fixed here by scoping the guard to pre-merge event
+    # types only.
+    local guard_event=0
+    case "$event_type" in
+        ci-complete|code-review-complete) guard_event=1 ;;
+    esac
 
     # Delivery-side stale-PR guard. An event that was valid at producer
     # time can become stale before we actually deliver it:
@@ -520,7 +540,7 @@ process_event_file() {
     # 4 back-to-back stale ci-complete events (PRs #427, #429 ×2, #431,
     # VA#943) all fired for PRs that were merged between event creation
     # and session consumption.
-    if [ -n "$pr_num" ]; then
+    if [ "$guard_event" = "1" ] && [ -n "$pr_num" ]; then
         # Call directly (NOT in $(...)) so cache mutations persist —
         # result is in $PR_STATE_RESULT. Format is "STATE|MERGED" or
         # "|" on API failure. Fail-open: deliver anyway rather than risk


### PR DESCRIPTION
<!-- claude-session: 2a0c99e5-6861-4ccd-8223-08ab7de19ab8 -->

## Summary

**Regression fix for PR #49.** The delivery-side merged-PR guard I shipped in PR #49 applied to ALL event types, but the premise "PR is merged → event is stale" is only true for **pre-merge** events (CI, code review). **Post-merge** events (deploy, verify) run BY DESIGN after merge — a merged PR is their expected context.

## What broke

On Olbrasoft/VirtualAssistant PR #945 deploy run 24476419604 (2026-04-15 20:21-20:23):

```
deploy.Notify Claude Code: Deploy event written to
  /home/jirka/.config/claude-channels/deploy-events/Olbrasoft-VirtualAssistant-deploy-d0f3b01-24476419604-1.json
deploy.Notify Claude Code: [wake-claude] DROP Olbrasoft-VirtualAssistant-deploy-d0f3b01-24476419604-1.json
  — PR #945 is already MERGED (stale at delivery, not waking)
```

Flow:
1. User merged PR #945 → Deploy VirtualAssistant workflow ran on merge commit `d0f3b01`
2. Workflow wrote the deploy-complete event file and called wake-claude.sh
3. wake-claude.sh extracted `commit: d0f3b01`, called `gh api commits/.../pulls` → pr_num=945
4. Checked PR #945 state → MERGED → **DROP**
5. Session indefinitely waited for deploy wake that never arrived

## Fix

Scope the guard on `event.event` type:

```bash
case "$event_type" in
    ci-complete|code-review-complete) guard_event=1 ;;
esac

if [ "$guard_event" = "1" ] && [ -n "$pr_num" ]; then
    # ... merged-PR check ...
fi
```

- `ci-complete`, `code-review-complete` → apply guard (merged = stale)
- `deploy-complete`, `verify-complete`, anything else → skip guard (deliver unconditionally)

## Test plan

- [x] Syntax: `bash -n hooks/wake-claude.sh`
- [x] Isolated: 6 cases × event type × merged state. Verified pre-merge+merged → DROP, post-merge+merged → DELIVER, pre-merge+open → DELIVER
- [ ] Field: after merge, verify next VA deploy triggers a wake event

🤖 Generated with [Claude Code](https://claude.com/claude-code)
