### PR TITLE
fix(hooks): inherit wake-claude.sh stderr to systemd journal (observability)

### DIFF
--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -146,7 +146,10 @@ def _wake(repo_name, branch=None):
         # receiver, so post-incident debugging starts from grep.
         # PIPE would risk kernel buffer fill / fd leak; None (inherit)
         # writes straight through to the journal with zero buffering.
-        proc = subprocess.Popen(args, stdout=subprocess.DEVNULL)
+        # stderr=None is explicit (not relying on the implicit default)
+        # so a future edit cannot silently reintroduce DEVNULL by setting
+        # only stdout. Copilot review on PR #51.
+        proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=None)
         # Reap the child in a background thread so it does not become a
         # zombie. wake-claude.sh can take up to WAKE_CLAUDE_RETRY_SECS to
         # finish; we never want to block the receiver waiting for it.

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -133,12 +133,20 @@ def _wake(repo_name, branch=None):
         args = [wake_script, repo_name]
         if branch:
             args.append(branch)
-        # Use DEVNULL for stderr — nothing reads the pipe in this process, so
-        # PIPE would let the kernel buffer fill up and eventually block the
-        # child or leak file descriptors over time. wake-claude.sh's own
-        # stderr is preserved by the systemd journal of gh-webhook-forward.service
-        # if we ever need to debug it; for that, run wake-claude.sh manually.
-        proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # IMPORTANT: stderr is INHERITED (None), not redirected to DEVNULL.
+        # wake-claude.sh emits diagnostic lines for every event it
+        # processes — DELIVERED, DEFER, DROP (stale-on-disk, ambiguous
+        # session, merged PR, etc.). When stderr was DEVNULL, all of
+        # those lines were lost to the void: the journal showed
+        # webhook-receiver saying "Wake signal sent" but no record of
+        # what wake-claude.sh actually DID with the signal. Observed
+        # 2026-04-15 23:02-23:17 on Olbrasoft/cr PR #434: 2 wake signals
+        # sent, session never woke, no clue why. Inheriting stderr lets
+        # wake-claude.sh log to the same systemd journal as the
+        # receiver, so post-incident debugging starts from grep.
+        # PIPE would risk kernel buffer fill / fd leak; None (inherit)
+        # writes straight through to the journal with zero buffering.
+        proc = subprocess.Popen(args, stdout=subprocess.DEVNULL)
         # Reap the child in a background thread so it does not become a
         # zombie. wake-claude.sh can take up to WAKE_CLAUDE_RETRY_SECS to
         # finish; we never want to block the receiver waiting for it.


### PR DESCRIPTION
<!-- claude-session: 2a0c99e5-6861-4ccd-8223-08ab7de19ab8 -->

## Summary

Critical observability gap: `webhook-receiver._wake()` ran wake-claude.sh with `stderr=DEVNULL`, so every diagnostic line wake-claude.sh emitted (DELIVERED, DEFER, DROP for ambiguous session / merged PR / stale-on-disk / no live Claude) was silently discarded.

The journal showed only "Wake signal sent" with **zero** record of what wake-claude.sh actually did with the signal.

## Triggering incident

2026-04-15 23:02-23:17 on Olbrasoft/cr PR #434:

```
23:02:18 [webhook-receiver] CI success event written: ... PR #434 (96cb3c7)
23:02:18 [webhook-receiver] Wake signal sent for Olbrasoft/cr branch=...
23:05:14 [webhook-receiver] CI success event written: ... PR #434 (4e6a0d1)
23:05:14 [webhook-receiver] Wake signal sent for Olbrasoft/cr branch=...
(silence — no record of what wake-claude.sh did)
→ user reports "nothing arrived in the cr session, why?"
```

There was no way to answer "why" from the journal. PR #49 added the explicit log lines in wake-claude.sh — but this `stderr=DEVNULL` blocked them from ever reaching the journal.

## Fix

Drop `stderr=DEVNULL` in `subprocess.Popen`, so the child inherits the parent's stderr (which IS the systemd journal). `PIPE` would risk kernel buffer fill / fd leak; inherit (None) writes straight through with zero buffering.

The original comment ("wake-claude.sh stderr is preserved by the journal") was factually wrong — DEVNULL was explicit and final.

## Test plan

- [x] Syntax: `python3 -c "import ast; ast.parse(...)"`
- [ ] Field: after merge + restart of gh-webhook-forward.service, trigger a wake event; verify both `webhook-receiver` AND `wake-claude` lines appear in `journalctl --user -u gh-webhook-forward.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
