### PR TITLE
fix(hooks): startup + loop drain for DEFER'd events

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,11 +97,14 @@ Wake happens within seconds of the GitHub event, while the session is still aliv
 │ │     Claude PID (multiple readers cause kernel-level         │     │
 │ │     event stealing)                                         │     │
 │ │  4. mkfifo /tmp/claude-wake/.session-{PID}.fifo             │     │
-│ │  5. cat $FIFO   ← blocks at zero CPU                        │     │
-│ │  6. On read: parse event, output instructions to stderr,    │     │
+│ │  5. STARTUP DRAIN: check disk for DEFER'd events first      │     │
+│ │     → if found, process + exit 2 (skip FIFO entirely)       │     │
+│ │  6. read $FIFO (120s timeout) ← blocks at zero CPU          │     │
+│ │  7. On timeout: LOOP DRAIN — check disk for DEFER'd events  │     │
+│ │  8. On read: parse event, output instructions to stderr,    │     │
 │ │     exit 2 → Claude Code re-prompts assistant with stderr   │     │
 │ │     as a system reminder (this IS the "wake")               │     │
-│ │  7. On real exit (Claude session dies): cleanup trap        │     │
+│ │  9. On real exit (Claude session dies): cleanup trap        │     │
 │ │     removes FIFO and manifest                               │     │
 │ └─────────────────────────────────────────────────────────────┘     │
 └──────────────────────────────────────────────────────────────────────┘

--- a/docs/session-wake-runbook.md
+++ b/docs/session-wake-runbook.md
@@ -11,11 +11,26 @@ This runbook exists because sessions repeatedly got stuck in one of these loops:
 
 ## What changed (2026-04-16)
 
+### Prescriptive wake instructions (PR #53)
+
 The wake event instructions injected by `wake-on-event.sh` have been rewritten to be **prescriptive, not advisory.** Previously, the ci-complete instructions said "check if comments already addressed" — sessions debated endlessly instead of merging. Now the instructions are a decision procedure:
 
 1. Run ONE command (`gh pr view` with specific jq)
 2. Match the FIRST applicable rule (no deliberation)
 3. Act (MERGE / WAIT / SKIP)
+
+### Startup drain + loop drain (PR #54)
+
+**The recurring deadlock was:** two events arrive close together (e.g., CI complete at 14:53, Copilot review at 14:54). The first event is delivered via FIFO. The second event arrives while the session is processing the first one (no FIFO reader available) → DEFER'd to disk. Previously, the disk file was only drained on `UserPromptSubmit` (user types something), which **never fires in autonomous mode** → session waits forever.
+
+**Fix:** `wake-on-event.sh` now has THREE delivery paths:
+1. **Startup drain** — on every hook spawn, check disk for pending events BEFORE blocking on FIFO
+2. **FIFO delivery** — instant wake via named pipe (primary path, unchanged)
+3. **Loop drain** — every 120s FIFO timeout, check disk for DEFER'd events
+
+The `check-deploy-status.sh` on UserPromptSubmit is now a tertiary fallback.
+
+### Reference
 
 The `ci-workflow-monitor` skill in `skills/ci-workflow-monitor/SKILL.md` has the full state machine (Phase A/B/C) and Critical Rule #7 about Copilot reviewing once. **Re-read the skill file** (`cat ~/Olbrasoft/GitHub.Actions.Notify/skills/ci-workflow-monitor/SKILL.md`) if you're unsure about the lifecycle.
 
@@ -185,6 +200,8 @@ ls -la ~/.config/claude-channels/deploy-events/
 | Wait for post-merge CI | Session hangs forever | Rule 3: main CI doesn't trigger wake |
 | Receive CI success but don't merge | Session sits idle | MERGE DECISION table: checks_pass + copilot reviewed → MERGE |
 | Receive CI failure but wait | Session sits idle | Fix immediately, don't wait for another wake |
+| Two events arrive close together | Second event DEFER'd, session waits forever | Startup drain + loop drain (PR #54): hook checks disk on spawn and every 120s |
+| Hook dies, session goes deaf | No reader, all events DEFER to disk | Startup drain on next hook spawn; if hook never spawns, user must type to trigger UserPromptSubmit fallback |
 
 ---
 

--- a/docs/wake-notification-system.md
+++ b/docs/wake-notification-system.md
@@ -46,12 +46,15 @@ GitHub
                             ├─► success → DELIVERED, rm event file
                             └─► timeout → DEFER (file kept), clean stale reader.lock
                                   │
-                                  └─► next user prompt triggers
-                                        UserPromptSubmit drain of the on-disk
-                                        event file (check-deploy-status.sh).
-                                        The FIFO reader is NOT involved in
-                                        this fallback path — it only matters
-                                        for immediate FIFO delivery.
+                                  ├─► PRIMARY: next wake-on-event.sh spawn
+                                  │     does startup drain (reads event from
+                                  │     disk before blocking on FIFO)
+                                  ├─► SECONDARY: loop drain every 120s while
+                                  │     hook is alive (FIFO read timeout →
+                                  │     check disk → process if found)
+                                  └─► TERTIARY: UserPromptSubmit drain
+                                        (check-deploy-status.sh) on next
+                                        user prompt — last resort
 ```
 
 ---
@@ -62,8 +65,8 @@ GitHub
 |---|---|---|
 | `webhook-receiver.py` | HTTP listener on :9877. Parses GitHub webhooks. Writes event files. Spawns wake-claude.sh. | Long-running systemd service |
 | `wake-claude.sh` | One-shot delivery transaction. Finds target session, writes to FIFO. | Spawned per event, exits when done |
-| `wake-on-event.sh` | asyncRewake hook in each Claude session. Blocks on FIFO. On read → exit 2 → injection. | Spawned by Claude Code on SessionStart and Stop |
-| `check-deploy-status.sh` | UserPromptSubmit hook. Drains pending event files on disk. Cleans stale reader.lock. | Runs on every user prompt |
+| `wake-on-event.sh` | asyncRewake hook in each Claude session. Startup drain (disk) → FIFO block (120s timeout) → loop drain (disk). On event → exit 2 → injection. | Spawned by Claude Code on SessionStart and Stop |
+| `check-deploy-status.sh` | UserPromptSubmit hook. Drains pending event files on disk. Cleans stale reader.lock. Tertiary fallback. | Runs on every user prompt |
 | `log-wake-feedback.sh` | Records session's classification (ok/late/stale/garbled/...) of received events to wake-feedback.md | Called explicitly from session after acting on a wake |
 | `start-webhook-forwards.sh` | systemd service entrypoint. Runs `gh webhook forward` for each configured repo + the receiver. | Long-running |
 
@@ -152,6 +155,7 @@ The event was never produced. Two sub-cases:
 | Stale event delivered after producer was correct | DEFER'd file delivered post-merge as stale wake | PR #49 | Delivery-side merged-PR guard in wake-claude.sh |
 | Deploy event dropped because PR is merged | session waited for deploy that was silently dropped | PR #50 | Guard scoped to ci-complete/code-review-complete only |
 | wake-claude.sh decisions invisible | journal showed "Wake signal sent" but no result | PR #51 | webhook-receiver inherits stderr instead of DEVNULL |
+| DEFER'd event never picked up (autonomous deadlock) | Session stuck waiting for FIFO event that was on disk | PR #54 | Added startup drain (check disk before FIFO) + loop drain (check disk every 120s on FIFO timeout) to wake-on-event.sh. Previously only UserPromptSubmit drained disk, which never fires in autonomous mode. |
 
 ---
 
@@ -165,7 +169,11 @@ These are NOT bugs to debug — they're inherent to the design. Don't waste time
 - The next `wake-claude.sh` DEFER (cleans the lock, but doesn't deliver — there's no reader)
 - The next `UserPromptSubmit` in that session (cleans the lock; the model's response triggers Stop → new reader)
 
-So between SIGKILL and the next user prompt, the session is "deaf" but events accumulate on disk and get drained on prompt.
+So between SIGKILL and the next user prompt, the session is "deaf" but events accumulate on disk. **Mitigation (PR #54):** when the next reader spawns, its startup drain picks up DEFER'd events from disk immediately. If the reader stays alive, the loop drain checks disk every 120s.
+
+### L1b — asyncRewake hook not spawned (session idle, no Stop event)
+
+Claude Code only spawns the asyncRewake hook on `SessionStart` and `Stop` events. If the hook exits (for any reason) while the session is idle at the prompt, there is no `Stop` event to trigger a respawn. The session goes deaf until the user types something. **Observed:** PID 9085 (cr session) had a zombie hook child (spawned at 14:16, died silently) and no replacement spawned for 50+ minutes. The startup drain can only help when the hook DOES spawn — it can't force Claude Code to spawn it. UserPromptSubmit (check-deploy-status.sh) remains the only recovery path for this case.
 
 ### L2 — Verify-complete race vs. manual verification
 
@@ -234,6 +242,7 @@ gh run view <RUN_ID> --repo <REPO> --log | grep -A 5 "Notify Claude Code"
 | `WAKE_CLAUDE_WRITE_TIMEOUT` | 3 | Per-attempt FIFO write timeout |
 | `WAKE_CLAUDE_MAX_EVENT_AGE` | 3600 | Drop event files older than this (sec) |
 | `WAKE_FEEDBACK_MAX_ENTRIES` | 5 | How many recent feedback entries check-deploy-status.sh surfaces on prompt |
+| `FIFO_TIMEOUT_SECS` | 120 | wake-on-event.sh FIFO read timeout; loop drain checks disk on each timeout (hardcoded, not env var) |
 
 ---
 

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -498,6 +498,46 @@ process_event() {
 }
 
 ###############################################################################
+# Startup drain: process DEFER'd events from disk before blocking on FIFO
+###############################################################################
+#
+# When wake-claude.sh cannot deliver via FIFO (session is busy processing
+# tools, no asyncRewake reader available), it DEFERs the event to disk:
+#   ~/.config/claude-channels/deploy-events/{REPO_PREFIX}*.json
+#
+# Previously, these DEFER'd files were only drained by check-deploy-status.sh
+# on UserPromptSubmit — which never fires in autonomous mode. This caused a
+# recurring deadlock:
+#
+#   1. CI event delivered via FIFO → session wakes, processes it
+#   2. Copilot review event arrives seconds later → no reader → DEFER'd to disk
+#   3. Session finishes CI processing → Stop → asyncRewake → new hook spawns
+#   4. New hook blocks on FIFO — but the review event is on DISK, not in FIFO
+#   5. Session waits forever for a FIFO event that will never come
+#
+# Fix: on every hook startup, check disk FIRST. If a pending event exists
+# for this repo, process it immediately and exit 2 (wake the session).
+# The FIFO is NOT opened during the drain to prevent a race where
+# wake-claude.sh writes to the FIFO (seeing a reader), but the data is
+# never consumed (we exit 2 for the disk event instead).
+
+EVENTS_DIR="${HOME}/.config/claude-channels/deploy-events"
+REPO_PREFIX=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' | tr '/' '-')
+
+if [ -n "$REPO_PREFIX" ] && [ -d "$EVENTS_DIR" ]; then
+    for event_file in "$EVENTS_DIR"/${REPO_PREFIX}*.json; do
+        [ -f "$event_file" ] || continue
+        event_data=$(cat "$event_file" 2>/dev/null)
+        rm -f "$event_file"
+        if [ -n "$event_data" ]; then
+            echo "[wake-on-event] Startup drain: processing DEFER'd event: $(basename "$event_file")" >&2
+            process_event "$event_data"
+            exit 2
+        fi
+    done
+fi
+
+###############################################################################
 # Main loop: block on FIFO
 ###############################################################################
 #
@@ -517,12 +557,19 @@ exec 3<>"$FIFO"
 
 # Re-check that the parent Claude process is still alive. The startup
 # suicide check at the top only fires once, but the loop below blocks
-# for up to 600s in `read`. If the parent dies during that block, the
-# hook gets reparented to systemd-user and would otherwise stay alive
-# forever, accumulating one orphan per dead session. See bug 32.
+# for up to FIFO_TIMEOUT_SECS in `read`. If the parent dies during
+# that block, the hook gets reparented to systemd-user and would
+# otherwise stay alive forever, accumulating one orphan per dead
+# session. See bug 32.
 parent_alive() {
     kill -0 "$CLAUDE_PID" 2>/dev/null
 }
+
+# FIFO read timeout (seconds). After each timeout the loop drains any
+# DEFER'd events from disk.  120s is a good balance between latency
+# (how long a DEFER'd event waits) and efficiency (how often we wake
+# from sleep to do a no-op glob).
+FIFO_TIMEOUT_SECS=120
 
 while true; do
     if ! parent_alive; then
@@ -531,11 +578,11 @@ while true; do
         exec 3<&-
         exit 0
     fi
-    # Read one NDJSON line with a 600s safety timeout. read returns 0 on
-    # success, non-zero on timeout (no input within 600s) or EOF (no
-    # writers — but FD 3 is also write-open, so we never see real EOF).
+    # Read one NDJSON line with a timeout. read returns 0 on success,
+    # non-zero on timeout or EOF (but FD 3 is also write-open, so we
+    # never see real EOF).
     EVENT_DATA=""
-    if IFS= read -r -t 600 EVENT_DATA <&3; then
+    if IFS= read -r -t "$FIFO_TIMEOUT_SECS" EVENT_DATA <&3; then
         if ! parent_alive; then
             exec 3<&-
             exit 0
@@ -545,8 +592,30 @@ while true; do
         exec 3<&-
         exit 2
     fi
-    # read timed out: nothing arrived in 600s. Refresh manifest with
-    # current cwd (cheap) and loop back.
+
+    ###########################################################################
+    # Loop drain: check disk for DEFER'd events on every FIFO timeout
+    ###########################################################################
+    #
+    # Same logic as startup drain but runs periodically while the hook is
+    # alive. Catches events that were DEFER'd by wake-claude.sh when this
+    # hook's FIFO had no reader (e.g. during a previous tool-execution gap
+    # that caused the prior hook instance to exit 2 for a different event).
+    if [ -n "$REPO_PREFIX" ] && [ -d "$EVENTS_DIR" ]; then
+        for event_file in "$EVENTS_DIR"/${REPO_PREFIX}*.json; do
+            [ -f "$event_file" ] || continue
+            event_data=$(cat "$event_file" 2>/dev/null)
+            rm -f "$event_file"
+            if [ -n "$event_data" ]; then
+                echo "[wake-on-event] Loop drain: processing DEFER'd event: $(basename "$event_file")" >&2
+                process_event "$event_data"
+                exec 3<&-
+                exit 2
+            fi
+        done
+    fi
+
+    # Refresh manifest with current cwd (cheap) and loop back.
     jq -n \
         --argjson pid "$CLAUDE_PID" \
         --arg fifo "$FIFO" \

--- a/hooks/wake-on-event.sh
+++ b/hooks/wake-on-event.sh
@@ -498,7 +498,7 @@ process_event() {
 }
 
 ###############################################################################
-# Startup drain: process DEFER'd events from disk before blocking on FIFO
+# Disk drain: process DEFER'd events from disk
 ###############################################################################
 #
 # When wake-claude.sh cannot deliver via FIFO (session is busy processing
@@ -515,27 +515,53 @@ process_event() {
 #   4. New hook blocks on FIFO — but the review event is on DISK, not in FIFO
 #   5. Session waits forever for a FIFO event that will never come
 #
-# Fix: on every hook startup, check disk FIRST. If a pending event exists
-# for this repo, process it immediately and exit 2 (wake the session).
-# The FIFO is NOT opened during the drain to prevent a race where
-# wake-claude.sh writes to the FIFO (seeing a reader), but the data is
-# never consumed (we exit 2 for the disk event instead).
+# Fix: drain_pending_events() is called on startup (before FIFO open) and
+# on every FIFO read timeout (loop drain). If a pending event exists for
+# this repo, process it immediately and exit 2 (wake the session).
+#
+# Note: event files are matched by repo prefix, not by target Claude PID.
+# This is consistent with check-deploy-status.sh. If two sessions exist for
+# the same repo, whichever drains first gets the event. In practice this is
+# rare because R4 (strict count==1 matching) prevents wake-claude.sh from
+# targeting ambiguous sessions. A future improvement could encode the target
+# PID into the DEFER'd filename for precise routing.
 
-EVENTS_DIR="${HOME}/.config/claude-channels/deploy-events"
+# Safe HOME/XDG resolution matching INVALID_PAYLOADS_DIR pattern — the
+# script runs under set -u, so bare $HOME aborts when HOME is unset.
+EVENTS_DIR=""
+if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    EVENTS_DIR="$XDG_CONFIG_HOME/claude-channels/deploy-events"
+elif [ -n "${HOME:-}" ]; then
+    EVENTS_DIR="${HOME}/.config/claude-channels/deploy-events"
+fi
 REPO_PREFIX=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' | tr '/' '-')
 
-if [ -n "$REPO_PREFIX" ] && [ -d "$EVENTS_DIR" ]; then
+# Shared drain logic used by both startup drain and loop drain.
+# Returns 0 without exiting if no events found; calls exit 2 if an event
+# was processed (never returns in that case).
+drain_pending_events() {
+    local origin="$1"
+    [ -n "$REPO_PREFIX" ] || return 0
+    [ -n "$EVENTS_DIR" ] || return 0
+    [ -d "$EVENTS_DIR" ] || return 0
+    local event_file event_data
     for event_file in "$EVENTS_DIR"/${REPO_PREFIX}*.json; do
         [ -f "$event_file" ] || continue
         event_data=$(cat "$event_file" 2>/dev/null)
         rm -f "$event_file"
         if [ -n "$event_data" ]; then
-            echo "[wake-on-event] Startup drain: processing DEFER'd event: $(basename "$event_file")" >&2
+            echo "[wake-on-event] $origin: processing DEFER'd event: $(basename "$event_file")" >&2
             process_event "$event_data"
             exit 2
         fi
     done
-fi
+}
+
+# Startup drain: check disk FIRST, before opening the FIFO. The FIFO is
+# NOT opened during drain to prevent a race where wake-claude.sh writes to
+# the FIFO (seeing a reader), but the data is never consumed (we exit 2
+# for the disk event instead).
+drain_pending_events "Startup drain"
 
 ###############################################################################
 # Main loop: block on FIFO
@@ -593,27 +619,11 @@ while true; do
         exit 2
     fi
 
-    ###########################################################################
-    # Loop drain: check disk for DEFER'd events on every FIFO timeout
-    ###########################################################################
-    #
-    # Same logic as startup drain but runs periodically while the hook is
-    # alive. Catches events that were DEFER'd by wake-claude.sh when this
-    # hook's FIFO had no reader (e.g. during a previous tool-execution gap
-    # that caused the prior hook instance to exit 2 for a different event).
-    if [ -n "$REPO_PREFIX" ] && [ -d "$EVENTS_DIR" ]; then
-        for event_file in "$EVENTS_DIR"/${REPO_PREFIX}*.json; do
-            [ -f "$event_file" ] || continue
-            event_data=$(cat "$event_file" 2>/dev/null)
-            rm -f "$event_file"
-            if [ -n "$event_data" ]; then
-                echo "[wake-on-event] Loop drain: processing DEFER'd event: $(basename "$event_file")" >&2
-                process_event "$event_data"
-                exec 3<&-
-                exit 2
-            fi
-        done
-    fi
+    # Loop drain: check disk for DEFER'd events on every FIFO timeout.
+    # Uses the same drain_pending_events() helper as the startup path.
+    # If an event is found, drain_pending_events calls exit 2 internally
+    # (FD 3 is cleaned up by the EXIT trap via cleanup).
+    drain_pending_events "Loop drain"
 
     # Refresh manifest with current cwd (cheap) and loop back.
     jq -n \


### PR DESCRIPTION
<!-- claude-session:  -->

Closes the recurring autonomous deadlock where two events arrive close together and the second one gets DEFER'd to disk but never picked up.

## Problem

When CI and Copilot review complete within ~90 seconds of each other:
1. CI event delivered via FIFO → session wakes, processes it
2. Copilot review event arrives → no FIFO reader (session busy) → DEFER'd to disk
3. Session checks PR state, sees copilot not yet reviewed → "WAIT for review wake"
4. Hook blocks on FIFO — but review event is on DISK, not FIFO
5. **Session waits forever** (autonomous mode → no UserPromptSubmit → no disk drain)

Observed on Olbrasoft/cr PR #460 at 14:53-14:55 today.

## Fix

Add two disk-drain mechanisms to `wake-on-event.sh`:

1. **Startup drain** — on every hook spawn, check disk for pending events BEFORE blocking on FIFO
2. **Loop drain** — FIFO timeout reduced from 600s to 120s; on each timeout, check disk

Three delivery paths (priority):
```
Startup drain (disk) → FIFO (instant) → Loop drain (disk, 120s)
                                          ↑
                                    check-deploy-status.sh = tertiary fallback
```

## Changes

- `hooks/wake-on-event.sh` — startup drain + loop drain + 120s FIFO timeout
- `docs/wake-notification-system.md` — updated architecture diagram, failure mode table (PR #54), L1b limitation
- `docs/session-wake-runbook.md` — documented the new drain mechanisms
- `docs/architecture.md` — updated hook lifecycle steps

## Test plan

- [ ] Verify hook installs: `./hooks/install.sh --force`
- [ ] Verify startup drain: create event file on disk, trigger Stop → hook should process it
- [ ] Verify loop drain: create event file, wait 120s → hook should process it
- [ ] Verify FIFO delivery still works (primary path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)