### PR TITLE
fix: channel fs.watch + premature CI success guard

### DIFF
--- a/channel/webhook.ts
+++ b/channel/webhook.ts
@@ -99,8 +99,9 @@ if (!REPO_PREFIX) {
 
   // Watch for new event files (handles direct creates)
   watch(EVENTS_DIR, (eventType, filename) => {
-    if (!filename || !filename.startsWith(REPO_PREFIX) || !filename.endsWith(".json")) return;
+    if (!filename || !filename.startsWith(REPO_PREFIX)) return;
     if (filename.endsWith(".tmp")) return; // skip temp files from atomic writes
+    if (!filename.endsWith(".json")) return;
     // Small delay to ensure file is fully written
     setTimeout(() => processEventFile(join(EVENTS_DIR, filename)), 100);
   });
@@ -121,7 +122,12 @@ function drainPending() {
   } catch {}
 }
 
+// In-flight guard: prevents duplicate sends when poll and watch fire for the same file
+const inFlight = new Set<string>();
+
 function processEventFile(filepath: string) {
+  if (inFlight.has(filepath)) return;
+  inFlight.add(filepath);
   try {
     if (!existsSync(filepath)) return;
     const content = readFileSync(filepath, "utf-8");
@@ -148,11 +154,11 @@ function processEventFile(filepath: string) {
       method: "notifications/claude/channel",
       params: { content, meta },
     }).then(() => {
-      // Delete only after successful send
       try { unlinkSync(filepath); } catch {}
+      inFlight.delete(filepath);
     }).catch((err) => {
       console.error(`[github-webhook] Failed to push ${basename(filepath)}: ${err}`);
-      // File stays on disk for retry on next watch trigger
+      inFlight.delete(filepath);
     });
   } catch (err) {
     console.error(`[github-webhook] Error processing ${filepath}: ${err}`);

--- a/channel/webhook.ts
+++ b/channel/webhook.ts
@@ -97,12 +97,17 @@ if (!REPO_PREFIX) {
   // Process any existing event files (startup drain)
   drainPending();
 
-  // Watch for new event files
+  // Watch for new event files (handles direct creates)
   watch(EVENTS_DIR, (eventType, filename) => {
     if (!filename || !filename.startsWith(REPO_PREFIX) || !filename.endsWith(".json")) return;
+    if (filename.endsWith(".tmp")) return; // skip temp files from atomic writes
     // Small delay to ensure file is fully written
     setTimeout(() => processEventFile(join(EVENTS_DIR, filename)), 100);
   });
+
+  // Fallback poll every 5s — catches files created via os.rename (atomic write)
+  // that fs.watch may miss on some Linux/inotify configurations.
+  setInterval(() => drainPending(), 5000);
 }
 
 function drainPending() {

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -342,6 +342,20 @@ class WebhookHandler(BaseHTTPRequestHandler):
                   file=sys.stderr)
             return
 
+        # Guard against premature "success" when only fast external checks
+        # (e.g. GitGuardian) have completed but the main CI workflow hasn't
+        # even registered its checks yet. With only 1 terminal check and
+        # 0 pending, statusCheckRollup simply doesn't contain the other
+        # checks — they don't exist yet, so they're not "pending" either.
+        # Deferring when total checks <= 1 prevents false-positive success
+        # events that would cause the session to merge failing code.
+        total_checks = agg["success"] + agg["failure"] + agg["skipped"]
+        if total_checks <= 1 and not agg["any_failure"]:
+            print(f"[webhook-receiver] PR #{pr_number}: only {total_checks} check(s) terminal, "
+                  f"too early to declare success — deferring (other workflows may not have registered yet)",
+                  file=sys.stderr)
+            return
+
         # All checks are terminal. Determine the final status.
         final_status = "failure" if agg["any_failure"] else "success"
 

--- a/hooks/webhook-receiver.py
+++ b/hooks/webhook-receiver.py
@@ -347,14 +347,29 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # even registered its checks yet. With only 1 terminal check and
         # 0 pending, statusCheckRollup simply doesn't contain the other
         # checks — they don't exist yet, so they're not "pending" either.
-        # Deferring when total checks <= 1 prevents false-positive success
-        # events that would cause the session to merge failing code.
+        #
+        # We defer when total checks <= 1 AND the check_suite event is
+        # less than 30 seconds old (grace window for other workflows to
+        # register). After 30s, if still only 1 check, allow it — the
+        # repo genuinely has only one check suite.
         total_checks = agg["success"] + agg["failure"] + agg["skipped"]
         if total_checks <= 1 and not agg["any_failure"]:
-            print(f"[webhook-receiver] PR #{pr_number}: only {total_checks} check(s) terminal, "
-                  f"too early to declare success — deferring (other workflows may not have registered yet)",
-                  file=sys.stderr)
-            return
+            # Check how old the check_suite event is
+            suite_created = check_suite.get("created_at", "")
+            grace_expired = True
+            if suite_created:
+                try:
+                    from email.utils import parsedate_to_datetime
+                    created_dt = datetime.fromisoformat(suite_created.replace("Z", "+00:00"))
+                    age_secs = (datetime.now(timezone.utc) - created_dt).total_seconds()
+                    grace_expired = age_secs > 30
+                except (ValueError, TypeError):
+                    pass
+            if not grace_expired:
+                print(f"[webhook-receiver] PR #{pr_number}: only {total_checks} check(s) terminal, "
+                      f"deferring for grace window (other workflows may not have registered yet)",
+                      file=sys.stderr)
+                return
 
         # All checks are terminal. Determine the final status.
         final_status = "failure" if agg["any_failure"] else "success"

--- a/scripts/test-fail.sh
+++ b/scripts/test-fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Intentional syntax error for CI failure notification test
+if [ -f /tmp/x
+echo broken

--- a/scripts/test-fail.sh
+++ b/scripts/test-fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Intentional syntax error for CI failure notification test
-if [ -f /tmp/x
-echo broken


### PR DESCRIPTION
<!-- claude-session:  -->

Closes #62 (partial — e2e testing)

## Summary
- Fix channel webhook.ts: add 5s poll fallback for os.rename files
- Fix webhook-receiver.py: defer when only 1 check terminal (premature success)
- Includes intentional bash syntax error to test CI FAILURE notification

## Test plan
- [ ] CI failure wake arrives (bash -n will fail on test-fail.sh)
- [ ] No premature success event (should defer until all checks register)

🤖 Generated with [Claude Code](https://claude.com/claude-code)