### PR TITLE
fix: prevent inFlight leak blocking channel delivery

### DIFF
--- a/channel/webhook.ts
+++ b/channel/webhook.ts
@@ -130,18 +130,23 @@ function processEventFile(filepath: string) {
   const now = Date.now();
   const startedAt = inFlight.get(filepath);
   if (startedAt && now - startedAt < 10_000) return;
-  inFlight.set(filepath, now);
+  // Per-attempt token: only the attempt whose token matches the current inFlight
+  // value is allowed to clear the entry / delete the file. Prevents a stale
+  // attempt's late resolution from clobbering a fresher attempt.
+  const token = now;
+  inFlight.set(filepath, token);
+  const ownsAttempt = () => inFlight.get(filepath) === token;
 
   try {
     if (!existsSync(filepath)) {
-      inFlight.delete(filepath);
+      if (ownsAttempt()) inFlight.delete(filepath);
       return;
     }
     const content = readFileSync(filepath, "utf-8");
 
     if (!content.trim()) {
       try { unlinkSync(filepath); } catch {}
-      inFlight.delete(filepath);
+      if (ownsAttempt()) inFlight.delete(filepath);
       return;
     }
 
@@ -163,14 +168,16 @@ function processEventFile(filepath: string) {
       params: { content, meta },
     }).then(() => {
       console.error(`[github-webhook] Delivered: ${basename(filepath)}`);
-      try { unlinkSync(filepath); } catch {}
-      inFlight.delete(filepath);
+      if (ownsAttempt()) {
+        try { unlinkSync(filepath); } catch {}
+        inFlight.delete(filepath);
+      }
     }).catch((err) => {
       console.error(`[github-webhook] Failed to push ${basename(filepath)}: ${err}`);
-      inFlight.delete(filepath);
+      if (ownsAttempt()) inFlight.delete(filepath);
     });
   } catch (err) {
     console.error(`[github-webhook] Error processing ${filepath}: ${err}`);
-    inFlight.delete(filepath);
+    if (ownsAttempt()) inFlight.delete(filepath);
   }
 }

--- a/channel/webhook.ts
+++ b/channel/webhook.ts
@@ -122,18 +122,26 @@ function drainPending() {
   } catch {}
 }
 
-// In-flight guard: prevents duplicate sends when poll and watch fire for the same file
-const inFlight = new Set<string>();
+// In-flight guard: prevents duplicate sends when poll and watch fire for the same file.
+// Entries expire after 10s to prevent permanent blocking if a promise hangs.
+const inFlight = new Map<string, number>();
 
 function processEventFile(filepath: string) {
-  if (inFlight.has(filepath)) return;
-  inFlight.add(filepath);
+  const now = Date.now();
+  const startedAt = inFlight.get(filepath);
+  if (startedAt && now - startedAt < 10_000) return;
+  inFlight.set(filepath, now);
+
   try {
-    if (!existsSync(filepath)) return;
+    if (!existsSync(filepath)) {
+      inFlight.delete(filepath);
+      return;
+    }
     const content = readFileSync(filepath, "utf-8");
 
     if (!content.trim()) {
-      unlinkSync(filepath);
+      try { unlinkSync(filepath); } catch {}
+      inFlight.delete(filepath);
       return;
     }
 
@@ -154,6 +162,7 @@ function processEventFile(filepath: string) {
       method: "notifications/claude/channel",
       params: { content, meta },
     }).then(() => {
+      console.error(`[github-webhook] Delivered: ${basename(filepath)}`);
       try { unlinkSync(filepath); } catch {}
       inFlight.delete(filepath);
     }).catch((err) => {
@@ -162,5 +171,6 @@ function processEventFile(filepath: string) {
     });
   } catch (err) {
     console.error(`[github-webhook] Error processing ${filepath}: ${err}`);
+    inFlight.delete(filepath);
   }
 }


### PR DESCRIPTION
<!-- claude-session:  -->

Closes part of channel delivery debugging.

## Summary
- Changed `inFlight` from Set to Map<string, number> with 10s TTL expiry
- Prevents permanent blocking when `mcp.notification()` promise hangs
- Clear inFlight on all early-return code paths (existsSync, empty content, catch)
- Added delivery confirmation logging

## Test plan
- [ ] Create PR → CI passes → verify channel event file is consumed within 5s
- [ ] Create PR with CI failure → verify failure event delivered
- [ ] Verify no stale event files accumulate in deploy-events/

🤖 Generated with [Claude Code](https://claude.com/claude-code)