### PR TITLE
test: intentional CI failure for channel negative-path E2E

### DIFF
--- a/channel/webhook.ts
+++ b/channel/webhook.ts
@@ -130,18 +130,23 @@ function processEventFile(filepath: string) {
   const now = Date.now();
   const startedAt = inFlight.get(filepath);
   if (startedAt && now - startedAt < 10_000) return;
-  inFlight.set(filepath, now);
+  // Per-attempt token: only the attempt whose token matches the current inFlight
+  // value is allowed to clear the entry / delete the file. Prevents a stale
+  // attempt's late resolution from clobbering a fresher attempt.
+  const token = now;
+  inFlight.set(filepath, token);
+  const ownsAttempt = () => inFlight.get(filepath) === token;
 
   try {
     if (!existsSync(filepath)) {
-      inFlight.delete(filepath);
+      if (ownsAttempt()) inFlight.delete(filepath);
       return;
     }
     const content = readFileSync(filepath, "utf-8");
 
     if (!content.trim()) {
       try { unlinkSync(filepath); } catch {}
-      inFlight.delete(filepath);
+      if (ownsAttempt()) inFlight.delete(filepath);
       return;
     }
 
@@ -163,14 +168,16 @@ function processEventFile(filepath: string) {
       params: { content, meta },
     }).then(() => {
       console.error(`[github-webhook] Delivered: ${basename(filepath)}`);
-      try { unlinkSync(filepath); } catch {}
-      inFlight.delete(filepath);
+      if (ownsAttempt()) {
+        try { unlinkSync(filepath); } catch {}
+        inFlight.delete(filepath);
+      }
     }).catch((err) => {
       console.error(`[github-webhook] Failed to push ${basename(filepath)}: ${err}`);
-      inFlight.delete(filepath);
+      if (ownsAttempt()) inFlight.delete(filepath);
     });
   } catch (err) {
     console.error(`[github-webhook] Error processing ${filepath}: ${err}`);
-    inFlight.delete(filepath);
+    if (ownsAttempt()) inFlight.delete(filepath);
   }
 }

--- a/channel/webhook.ts
+++ b/channel/webhook.ts
@@ -122,18 +122,26 @@ function drainPending() {
   } catch {}
 }
 
-// In-flight guard: prevents duplicate sends when poll and watch fire for the same file
-const inFlight = new Set<string>();
+// In-flight guard: prevents duplicate sends when poll and watch fire for the same file.
+// Entries expire after 10s to prevent permanent blocking if a promise hangs.
+const inFlight = new Map<string, number>();
 
 function processEventFile(filepath: string) {
-  if (inFlight.has(filepath)) return;
-  inFlight.add(filepath);
+  const now = Date.now();
+  const startedAt = inFlight.get(filepath);
+  if (startedAt && now - startedAt < 10_000) return;
+  inFlight.set(filepath, now);
+
   try {
-    if (!existsSync(filepath)) return;
+    if (!existsSync(filepath)) {
+      inFlight.delete(filepath);
+      return;
+    }
     const content = readFileSync(filepath, "utf-8");
 
     if (!content.trim()) {
-      unlinkSync(filepath);
+      try { unlinkSync(filepath); } catch {}
+      inFlight.delete(filepath);
       return;
     }
 
@@ -154,6 +162,7 @@ function processEventFile(filepath: string) {
       method: "notifications/claude/channel",
       params: { content, meta },
     }).then(() => {
+      console.error(`[github-webhook] Delivered: ${basename(filepath)}`);
       try { unlinkSync(filepath); } catch {}
       inFlight.delete(filepath);
     }).catch((err) => {
@@ -162,5 +171,6 @@ function processEventFile(filepath: string) {
     });
   } catch (err) {
     console.error(`[github-webhook] Error processing ${filepath}: ${err}`);
+    inFlight.delete(filepath);
   }
 }

--- a/scripts/_test_intentional_failure.sh
+++ b/scripts/_test_intentional_failure.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Intentionally broken bash for CI failure test
+if [ -f /tmp/x  # missing closing bracket → bash -n will fail
+  echo "broken"
+fi


### PR DESCRIPTION
<!-- claude-session:  -->

## Purpose
Verify that **ci-complete (status: failure)** events are delivered via the new MCP channel server (channel/webhook.ts).

## What this does
- Adds scripts/_test_intentional_failure.sh with a deliberate bash syntax error
- The "bash -n" CI check will fail
- A ci-complete event with status=failure should be written to ~/.config/claude-channels/deploy-events/
- The channel server should consume the file and push the event to the GitHub.Actions.Notify session

## Expected outcome
- This PR will NOT be merged
- It will be closed (without merge) after verifying the channel delivers the failure event

## Test plan
- [ ] CI fails as expected
- [ ] Event file appears in deploy-events with status=failure
- [ ] Event file is consumed within 10s
- [ ] PR closed without merge, branch deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)